### PR TITLE
Fix multiple styles with margin

### DIFF
--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -83,7 +83,7 @@ DocMeasure.prototype.measureNode = function(node) {
 
 			for(var i = styleArray.length - 1; i >= 0; i--) {
 				var styleName = styleArray[i];
-				var style = self.styleStack.styleDictionary[node.style];
+				var style = self.styleStack.styleDictionary[styleName];
 				if (style && style.margin) {
 					margin = style.margin;
 					break;


### PR DESCRIPTION
I found an issue when trying to apply multiple styles with margin to a node. This pull fixes the issue.

**Configuration:**

``` javascript
styles: {
    header: {
        color: "gray"
    },
    indent: {
        margin: [20, 0, 0, 0]
    }
}
```

**Node:**

``` javascript
{ text: "Test 1", style: ["header", "indent"] }
```
