### PR TITLE
Fixed Minified version not working

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,10 @@ module.exports = function(grunt) {
 					sourceMap: true,
 					compress: {
 						drop_console: true
-					}
+					},
+					mangle: {
+        				except: ['HeadTable', 'NameTable', 'CmapTable', 'HheaTable', 'MaxpTable', 'HmtxTable', 'PostTable', 'OS2Table', 'LocaTable', 'GlyfTable']
+      				}
 				},
 				files: {
 					'build/pdfmake.min.js': ['build/pdfmake.js']


### PR DESCRIPTION
This pull fixes issues with minified version not working
The base pdfkit library used some code ([**here**](https://github.com/devongovett/pdfkit/blob/master/lib/font/table.coffee#L3-L3) and [**here**](https://github.com/devongovett/pdfkit/blob/master/lib/font/ttf.coffee#L71-L80)) that rely on function names at runtime; 

as the uglify task by default enable name mangling for function name...

this should close #18 and #60 
