### PR TITLE
TableProcessor.endRow should restore resevedAtBottom on the right context

### DIFF
--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -135,6 +135,7 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
     var self = this;
 
     writer.context().moveDown(this.layout.paddingBottom(rowIndex, this.tableNode));
+    writer.context().availableHeight += this.reservedAtBottom;
 
     var endingPage = writer.context().page;
     var endingY = writer.context().y;
@@ -239,8 +240,6 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
       writer.pushToRepeatables(this.headerRepeatable);
       this.headerRepeatable = null;
     }
-
-    writer.context().availableHeight += this.reservedAtBottom;
 
     function getLineXs() {
       var result = [];


### PR DESCRIPTION
This pull fix a bug that causes `TableProcessor.endRow()` to miscalculates the available height when the `dontBreakRows` is set to `true`. [**plunker example**](http://plnkr.co/edit/ZQjyJ5v2WSt6vbhIBbcm?p=preview)

![image](https://cloud.githubusercontent.com/assets/5453835/4269575/2e6631d6-3cbe-11e4-99ea-c537d3223f15.png)

when `dontBreakRows` is set the space is reserved in the nested `DocumentContext`  (created by `beginUnbreakableBlock()` ) and restored on the top context (because `commitUnbreakableBlock()` is called before the space is restaured).

Related to issue #86 (there is still the border and break-on-padding questions)
