### PR TITLE
This PR fixes an issue with generating pdf's on client side with autoPri...

### DIFF
--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -55,21 +55,22 @@ Document.prototype.open = function(message) {
 };
 
 
-Document.prototype.print = function(timeout) {
-	timeout = timeout || 2000;
+Document.prototype.print = function() {
+  this.getDataUrl(function(dataUrl) {
+    var iFrame = document.createElement('iframe');
+    iFrame.style.position = 'absolute';
+    iFrame.style.left = '-99999px';
+    iFrame.src = dataUrl;
+    iFrame.onload = function() {
+      function removeIFrame(){
+        document.body.removeChild(iFrame);
+        document.removeEventListener('click', removeIFrame);
+      }
+      document.addEventListener('click', removeIFrame, false);
+    };
 
-	this.getDataUrl(function(dataUrl) {
-		var iFrame = document.createElement('iframe');
-		iFrame.style.display = 'none';
-		iFrame.src = dataUrl;
-		iFrame.onload = function() {
-			setTimeout(function() {
-				document.body.removeChild(iFrame);
-			}, timeout);
-		};
-
-		document.body.appendChild(iFrame);
-	}, { autoPrint: true });
+    document.body.appendChild(iFrame);
+  }, { autoPrint: true });
 };
 
 Document.prototype.download = function(defaultFileName) {


### PR DESCRIPTION
...nt turned on. Previous verion inserted an iframe with the pdf and then removed it in a timeout. This resulted that Firefox couldn't print it from an iframe that has already been removed. Also switching between printers yielded in an error. Currently the iframe is removed upon first click somewhere on the page.
