### PR TITLE
Add the type to the font name for pdfkit.

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -410,7 +410,7 @@ FontProvider.prototype.provideFont = function(familyName, bold, italics) {
 	if (cached) return cached;
 
 	var fontCache = (this.cache[familyName] = this.cache[familyName] || {});
-	fontCache[type] = this.pdfDoc.font(this.fonts[familyName][type], familyName)._font;
+	fontCache[type] = this.pdfDoc.font(this.fonts[familyName][type], familyName + ' (' + type + ')')._font;
 	return fontCache[type];
 };
 


### PR DESCRIPTION
This is to avoid using the same type (normal, bold, italics,
bolditalics) every time a font is requested.

Fixes #162.