### PR TITLE
Add the capability to have switch of page orientation per page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "grunt-browserify": "~1.3.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-dump-dir": "~0.1.2",
-    "grunt-contrib-concat": "~0.3.0"
+    "grunt-contrib-concat": "~0.3.0",
+    "sinon": "~1.12.2"
   },
   "scripts": {
     "test": "grunt test"

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -117,15 +117,16 @@ DocumentContext.prototype.moveDown = function(offset) {
 DocumentContext.prototype.moveToPageTop = function() {
 	this.y = this.pageMargins.top;
 	this.availableHeight = this.pageSize.height - this.pageMargins.top - this.pageMargins.bottom;
+	this.availableWidth = this.pageSize.width - this.pageMargins.left - this.pageMargins.right;
 };
 
 DocumentContext.prototype.addPage = function() {
 	var page = this.getDefaultPage();
-    this.pages.push(page);
+	this.pages.push(page);
 	this.page = this.pages.length - 1;
 	this.moveToPageTop();
 
-    this.tracker.emit('pageAdded');
+	this.tracker.emit('pageAdded');
     
 	return page;
 };

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -114,17 +114,25 @@ DocumentContext.prototype.moveDown = function(offset) {
 	return this.availableHeight > 0;
 };
 
-DocumentContext.prototype.moveToPageTop = function() {
+DocumentContext.prototype.initializePage = function() {
 	this.y = this.pageMargins.top;
 	this.availableHeight = this.pageSize.height - this.pageMargins.top - this.pageMargins.bottom;
-	this.availableWidth = this.pageSize.width - this.pageMargins.left - this.pageMargins.right;
+	this.pageSnapshot().availableWidth = this.pageSize.width - this.pageMargins.left - this.pageMargins.right;
+};
+
+DocumentContext.prototype.pageSnapshot = function(){
+  if(this.snapshots[0]){
+    return this.snapshots[0];
+  } else {
+    return this;
+  }
 };
 
 DocumentContext.prototype.addPage = function() {
 	var page = this.getDefaultPage();
 	this.pages.push(page);
 	this.page = this.pages.length - 1;
-	this.moveToPageTop();
+	this.initializePage();
 
 	this.tracker.emit('pageAdded');
     

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -125,8 +125,10 @@ DocumentContext.prototype.pageSnapshot = function(){
   }
 };
 
-function pageOrientation(pageOrientationString){
-	if(pageOrientationString === 'landscape'){
+function pageOrientation(pageOrientationString, currentPageOrientation){
+	if(pageOrientationString === undefined) {
+		return currentPageOrientation;
+	} else if(pageOrientationString === 'landscape'){
 		return 'landscape';
 	} else {
 		return 'portrait';
@@ -135,7 +137,7 @@ function pageOrientation(pageOrientationString){
 
 var getPageSize = function (currentPage, newPageOrientation) {
 	
-	newPageOrientation = pageOrientation(newPageOrientation);
+	newPageOrientation = pageOrientation(newPageOrientation, currentPage.pageSize.orientation);
 	
 	if(newPageOrientation !== currentPage.pageSize.orientation) {
 		return {

--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -233,7 +233,7 @@ ElementWriter.prototype.addFragment = function(block, useBlockXOffset, useBlockY
 */
 ElementWriter.prototype.pushContext = function(contextOrWidth, height) {
 	if (contextOrWidth === undefined) {
-		height = this.context.pageSize.height - this.context.pageMargins.top - this.context.pageMargins.bottom;
+		height = this.context.getCurrentPage().height - this.context.pageMargins.top - this.context.pageMargins.bottom;
 		contextOrWidth = this.context.availableWidth;
 	}
 

--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -13,7 +13,7 @@ var DocumentContext = require('./documentContext');
 function ElementWriter(context, tracker) {
 	this.context = context;
 	this.contextStack = [];
-	this.tracker = tracker || { emit: function() { } };
+	this.tracker = tracker;
 }
 
 function addPageItem(page, item, index) {
@@ -116,9 +116,9 @@ ElementWriter.prototype.addQr = function(qr, index) {
 
 	qr.x = context.x + (qr.x || 0);
 	qr.y = context.y;
-	
+
 	this.alignImage(qr);
-	
+
 	for (var i=0, l=qr._canvas.length; i < l; i++) {
 		var vector = qr._canvas[i];
 		vector.x += qr.x;
@@ -194,7 +194,7 @@ ElementWriter.prototype.addFragment = function(block, useBlockXOffset, useBlockY
                     item: l
                 });
                 break;
-                
+
             case 'vector':
                 var v = pack(item.item);
 
@@ -204,7 +204,7 @@ ElementWriter.prototype.addFragment = function(block, useBlockXOffset, useBlockY
                     item: v
                 });
                 break;
-                
+
             case 'image':
                 var img = pack(item.item);
 

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -216,9 +216,6 @@ LayoutBuilder.prototype.processNode = function(node) {
 		var margin = node._margin;
 
     if (node.pageBreak === 'before') {
-      self.writer.moveToNextPage();
-    }
-    if (node.pageOrientation) {
       self.writer.moveToNextPage(node.pageOrientation);
     }
     if (margin) {
@@ -234,7 +231,7 @@ LayoutBuilder.prototype.processNode = function(node) {
 		}
 
     if (node.pageBreak === 'after') {
-      self.writer.moveToNextPage();
+      self.writer.moveToNextPage(node.pageOrientation);
     }
 
 	}

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -81,7 +81,7 @@ LayoutBuilder.prototype.addBackground = function(background) {
 };
 
 LayoutBuilder.prototype.addStaticRepeatable = function(node, sizeFunction) {
-  this.addDynamicRepeatable(function() {return node}, sizeFunction);
+  this.addDynamicRepeatable(function() {return node;}, sizeFunction);
 };
 
 LayoutBuilder.prototype.addDynamicRepeatable = function(nodeGetter, sizeFunction) {
@@ -118,7 +118,7 @@ LayoutBuilder.prototype.addHeadersAndFooters = function(header, footer) {
       y: pageSize.height - pageMargins.bottom,
       width: pageSize.width,
       height: pageMargins.bottom
-    }
+    };
   };
   
   if(isFunction(header)) {

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -208,10 +208,12 @@ LayoutBuilder.prototype.processNode = function(node) {
 		var margin = node._margin;
 
     if (node.pageBreak === 'before') {
-        self.writer.moveToNextPage();
+      self.writer.moveToNextPage();
     }
-
-		if (margin) {
+    if (node.pageOrientation) {
+      self.writer.moveToNextPage(node.pageOrientation);
+    }
+    if (margin) {
 			self.writer.context().moveDown(margin[1]);
 			self.writer.context().addMargin(margin[0], margin[2]);
 		}
@@ -224,8 +226,9 @@ LayoutBuilder.prototype.processNode = function(node) {
 		}
 
     if (node.pageBreak === 'after') {
-        self.writer.moveToNextPage();
+      self.writer.moveToNextPage();
     }
+
 	}
 };
 

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -73,56 +73,64 @@ LayoutBuilder.prototype.addBackground = function(background) {
     var pageBackground = backgroundGetter(this.writer.context().page + 1);
     
     if (pageBackground) {
-      this.writer.beginUnbreakableBlock(this.pageSize.width, this.pageSize.height);
+      var pageSize = this.writer.context().getCurrentPage().pageSize;
+      this.writer.beginUnbreakableBlock(pageSize.width, pageSize.height);
       this.processNode(this.docMeasure.measureDocument(pageBackground));
       this.writer.commitUnbreakableBlock(0, 0);
     }
 };
 
-LayoutBuilder.prototype.addStaticRepeatable = function(node, x, y, width, height) {
-  var pages = this.writer.context().pages;
-  this.writer.context().page = 0;
-  
-  this.writer.beginUnbreakableBlock(width, height);
-  this.processNode(this.docMeasure.measureDocument(node));
-  var repeatable = this.writer.currentBlockToRepeatable();
-  repeatable.xOffset = x;
-  repeatable.yOffset = y;
-  this.writer.commitUnbreakableBlock(x, y);
-  
-  for(var i = 1, l = pages.length; i < l; i++) {
-    this.writer.context().page = i;
-    this.writer.addFragment(repeatable, true, true, true);
-  }
+LayoutBuilder.prototype.addStaticRepeatable = function(node, sizeFunction) {
+  this.addDynamicRepeatable(function() {return node}, sizeFunction);
 };
 
-LayoutBuilder.prototype.addDynamicRepeatable = function(nodeGetter, x, y, width, height) {
+LayoutBuilder.prototype.addDynamicRepeatable = function(nodeGetter, sizeFunction) {
   var pages = this.writer.context().pages;
   
-  for(var i = 0, l = pages.length; i < l; i++) {
-    this.writer.context().page = i;
+  for(var pageIndex = 0, l = pages.length; pageIndex < l; pageIndex++) {
+    this.writer.context().page = pageIndex;
 
-    var node = nodeGetter(i + 1, l);
+
+    var node = nodeGetter(pageIndex + 1, l);
 
     if (node) {
-      this.writer.beginUnbreakableBlock(width, height);
+      var sizes = sizeFunction(this.writer.context().getCurrentPage().pageSize, this.pageMargins);
+      this.writer.beginUnbreakableBlock(sizes.width, sizes.height);
       this.processNode(this.docMeasure.measureDocument(node));
-      this.writer.commitUnbreakableBlock(x, y);
+      this.writer.commitUnbreakableBlock(sizes.x, sizes.y);
     }
   }
 };
 
 LayoutBuilder.prototype.addHeadersAndFooters = function(header, footer) {
+  var headerSizeFct = function(pageSize, pageMargins){
+    return {
+      x: 0,
+      y: 0,
+      width: pageSize.width,
+      height: pageMargins.top
+    };
+  };
+  
+  var footerSizeFct = function (pageSize, pageMargins) {
+    return {
+      x: 0,
+      y: pageSize.height - pageMargins.bottom,
+      width: pageSize.width,
+      height: pageMargins.bottom
+    }
+  };
+  
   if(isFunction(header)) {
-    this.addDynamicRepeatable(header, 0, 0, this.pageSize.width, this.pageMargins.top);
+    this.addDynamicRepeatable(header, headerSizeFct);
   } else if(header) {
-    this.addStaticRepeatable(header, 0, 0, this.pageSize.width, this.pageMargins.top);
+    this.addStaticRepeatable(header, headerSizeFct);
   }
   
   if(isFunction(footer)) {
-    this.addDynamicRepeatable(footer, 0, this.pageSize.height - this.pageMargins.bottom, this.pageSize.width, this.pageMargins.bottom);
+    this.addDynamicRepeatable(footer, footerSizeFct);
   } else if(footer) {
-    this.addStaticRepeatable(footer, 0, this.pageSize.height - this.pageMargins.bottom, this.pageSize.width, this.pageMargins.bottom);
+    this.addStaticRepeatable(footer, 0, headerSizeFct());
   }
 };
 

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -57,7 +57,8 @@ PageElementWriter.prototype.moveToNextPage = function(pageOrientation) {
 	var prevPage = this.writer.context.page;
 	var prevY = this.writer.context.y;
 
-	if (nextPageIndex >= this.writer.context.pages.length) {
+	var newPageNeeded = nextPageIndex >= this.writer.context.pages.length;
+  if (newPageNeeded) {
 
 		var ctxPageOrientation = this.writer.context.pageOrientation;
     var previousPageOrientation = ctxPageOrientation === undefined || ctxPageOrientation === 'portrait' ? 'portrait' : 'landscape';
@@ -124,7 +125,7 @@ PageElementWriter.prototype.commitUnbreakableBlock = function(forcedX, forcedY) 
 					}
 				}
 			} else {
-				fragment.height = unbreakableContext.y;	
+				fragment.height = unbreakableContext.y;
 			}
 
 			if (forcedX !== undefined || forcedY !== undefined) {

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -52,45 +52,23 @@ PageElementWriter.prototype.addFragment = function(fragment, useBlockXOffset, us
 };
 
 PageElementWriter.prototype.moveToNextPage = function(pageOrientation) {
-	var nextPageIndex = this.writer.context.page + 1;
-
-	var prevPage = this.writer.context.page;
-	var prevY = this.writer.context.y;
-
-	var newPageNeeded = nextPageIndex >= this.writer.context.pages.length;
-  if (newPageNeeded) {
-
-		var ctxPageOrientation = this.writer.context.pageOrientation;
-    var previousPageOrientation = ctxPageOrientation === undefined || ctxPageOrientation === 'portrait' ? 'portrait' : 'landscape';
-
-		if(pageOrientation !== undefined && pageOrientation !== previousPageOrientation) {
-			var width = this.writer.context.pageSize.width;
-			this.writer.context.pageSize.width = this.writer.context.pageSize.height;
-			this.writer.context.pageSize.height = width;
-			this.writer.context.pageOrientation = pageOrientation;
-		}
-
-		// create new Page
-    var newPage = this.writer.context.addPage();
-		newPage.pageOrientation = pageOrientation;
-
-		// add repeatable fragments
+	
+	var nextPage = this.writer.context.moveToNextPage(pageOrientation);
+	
+  if (nextPage.newPageCreated) {
 		this.repeatables.forEach(function(rep) {
 			this.writer.addFragment(rep, true);
 		}, this);
 	} else {
-		this.writer.context.page = nextPageIndex;
-		this.writer.context.initializePage();
-
 		this.repeatables.forEach(function(rep) {
 			this.writer.context.moveDown(rep.height);
 		}, this);
 	}
 
 	this.writer.tracker.emit('pageChanged', {
-		prevPage: prevPage,
-		prevY: prevY,
-		y: this.writer.context.y
+		prevPage: nextPage.prevPage,
+		prevY: nextPage.prevY,
+		y: nextPage.y
 	});
 };
 

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -59,12 +59,14 @@ PageElementWriter.prototype.moveToNextPage = function(pageOrientation) {
 
 	if (nextPageIndex >= this.writer.context.pages.length) {
 
-		var previousPageOrientation = this.pageOrientation === undefined || this.pageOrientation == 'portrait' ? 'portrait' : 'landscape';
+		var ctxPageOrientation = this.writer.context.pageOrientation;
+    var previousPageOrientation = ctxPageOrientation === undefined || ctxPageOrientation === 'portrait' ? 'portrait' : 'landscape';
 
 		if(pageOrientation !== undefined && pageOrientation !== previousPageOrientation) {
 			var width = this.writer.context.pageSize.width;
 			this.writer.context.pageSize.width = this.writer.context.pageSize.height;
 			this.writer.context.pageSize.height = width;
+			this.writer.context.pageOrientation = pageOrientation;
 		}
 
 		// create new Page

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -51,15 +51,25 @@ PageElementWriter.prototype.addFragment = function(fragment, useBlockXOffset, us
 	}
 };
 
-PageElementWriter.prototype.moveToNextPage = function() {
+PageElementWriter.prototype.moveToNextPage = function(pageOrientation) {
 	var nextPageIndex = this.writer.context.page + 1;
 
 	var prevPage = this.writer.context.page;
 	var prevY = this.writer.context.y;
 
 	if (nextPageIndex >= this.writer.context.pages.length) {
+
+		var previousPageOrientation = this.pageOrientation === undefined || this.pageOrientation == 'portrait' ? 'portrait' : 'landscape';
+
+		if(pageOrientation !== undefined && pageOrientation !== previousPageOrientation) {
+			var width = this.writer.context.pageSize.width;
+			this.writer.context.pageSize.width = this.writer.context.pageSize.height;
+			this.writer.context.pageSize.height = width;
+		}
+
 		// create new Page
-        this.writer.context.addPage();
+    var newPage = this.writer.context.addPage();
+		newPage.pageOrientation = pageOrientation;
 
 		// add repeatable fragments
 		this.repeatables.forEach(function(rep) {

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -79,7 +79,7 @@ PageElementWriter.prototype.moveToNextPage = function(pageOrientation) {
 		}, this);
 	} else {
 		this.writer.context.page = nextPageIndex;
-		this.writer.context.moveToPageTop();
+		this.writer.context.initializePage();
 
 		this.repeatables.forEach(function(rep) {
 			this.writer.context.moveDown(rep.height);

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -95,9 +95,9 @@ PageElementWriter.prototype.commitUnbreakableBlock = function(forcedX, forcedY) 
 			if(nbPages > 1) {
 				// on out-of-context blocs (headers, footers, background) height should be the whole DocumentContext height
 				if (forcedX !== undefined || forcedY !== undefined) {
-					fragment.height = unbreakableContext.pageSize.height - unbreakableContext.pageMargins.top - unbreakableContext.pageMargins.bottom;
+					fragment.height = unbreakableContext.getCurrentPage().pageSize.height - unbreakableContext.pageMargins.top - unbreakableContext.pageMargins.bottom;
 				} else {
-					fragment.height = this.writer.context.pageSize.height - this.writer.context.pageMargins.top - this.writer.context.pageMargins.bottom;
+					fragment.height = this.writer.context.getCurrentPage().pageSize.height - this.writer.context.pageMargins.top - this.writer.context.pageMargins.bottom;
 					for (var i = 0, l = this.repeatables.length; i < l; i++) {
 						fragment.height -= this.repeatables[i].height;
 					}

--- a/src/printer.js
+++ b/src/printer.js
@@ -75,8 +75,9 @@ PdfPrinter.prototype.createPdfKitDocument = function(docDefinition, options) {
 	var pageSize = pageSize2widthAndHeight(docDefinition.pageSize || 'a4');
 
   if(docDefinition.pageOrientation === 'landscape') {
-    pageSize = { width: pageSize.height, height: pageSize.width };
+    pageSize = { width: pageSize.height, height: pageSize.width};
   }
+	pageSize.orientation = docDefinition.pageOrientation === 'landscape' ? docDefinition.pageOrientation : 'portrait';
 
 	this.pdfKitDoc = new PdfKit({ size: [ pageSize.width, pageSize.height ], compress: false});
 	this.pdfKitDoc.info.Producer = 'pdfmake';
@@ -203,7 +204,7 @@ function StringObject(str){
 function updatePageOrientationInOptions(currentPage, pdfKitDoc) {
 	var previousPageOrientation = pdfKitDoc.options.size[0] > pdfKitDoc.options.size[1] ? 'landscape' : 'portrait';
 
-	if(currentPage.pageOrientation !== undefined && currentPage.pageOrientation !== previousPageOrientation) {
+	if(currentPage.pageSize.orientation !== previousPageOrientation) {
 		var width = pdfKitDoc.options.size[0];
 		var height = pdfKitDoc.options.size[1];
 		pdfKitDoc.options.size = [height, width];

--- a/src/printer.js
+++ b/src/printer.js
@@ -200,10 +200,21 @@ function StringObject(str){
 	};
 }
 
+function updatePageOrientationInOptions(currentPage, pdfKitDoc) {
+	var previousPageOrientation = pdfKitDoc.options.size[0] > pdfKitDoc.options.size[1] ? 'landscape' : 'portrait';
+
+	if(currentPage.pageOrientation !== undefined && currentPage.pageOrientation !== previousPageOrientation) {
+		var width = pdfKitDoc.options.size[0];
+		var height = pdfKitDoc.options.size[1];
+		pdfKitDoc.options.size = [height, width];
+	}
+}
+
 function renderPages(pages, fontProvider, pdfKitDoc) {
-	for(var i = 0, l = pages.length; i < l; i++) {
+	for (var i = 0; i < pages.length; i++) {
 		if (i > 0) {
-			pdfKitDoc.addPage();
+			updatePageOrientationInOptions(pages[i], pdfKitDoc);
+			pdfKitDoc.addPage(pdfKitDoc.options);
 		}
 
 		setFontRefs(fontProvider, pdfKitDoc);

--- a/tests/documentContext.js
+++ b/tests/documentContext.js
@@ -232,16 +232,28 @@ describe('DocumentContext', function() {
 			assert.equal(page, pc.pages[pc.pages.length - 1]);
 		});
 
-		it('should set y, availableHeight and availableWidth to initial values', function() {
+		it('should set y, availableHeight and availableWidth on page to initial values', function() {
 			pc.y = 123;
 			pc.availableHeight = 123;
 
-			pc.moveToPageTop();
+			pc.initializePage();
 
 			assert.equal(pc.y, 60);
 			assert.equal(pc.availableHeight, 800 - 60 - 60);
 			assert.equal(pc.availableWidth, 400 - 40 - 40);
 		});
+
+    it('should keep column width when in column group, but set page width', function() {
+      pc.beginColumnGroup();
+      pc.beginColumn(100, 0, {});
+      pc.initializePage();
+
+      assert.equal(pc.availableWidth, 100);
+
+      pc.completeColumnGroup();
+
+      assert.equal(pc.availableWidth, 400 - 40 - 40);
+    });
 	});
 
 	describe('bottomMostContext', function() {

--- a/tests/documentContext.js
+++ b/tests/documentContext.js
@@ -220,14 +220,22 @@ describe('DocumentContext', function() {
 	});
 
 	describe('addPage', function() {
+		
+		var pageSize;
+		
+		beforeEach(function(){
+			pageSize = {width: 200, height: 400, orientation: 'landscape'};
+		});
+		
 		it('should add a new page', function() {
-			pc.addPage();
+			
+      pc.addPage(pageSize);
 
 			assert.equal(pc.pages.length, 2);
 		});
 
 		it('should return added page', function() {
-			var page = pc.addPage();
+			var page = pc.addPage(pageSize);
 
 			assert.equal(page, pc.pages[pc.pages.length - 1]);
 		});

--- a/tests/documentContext.js
+++ b/tests/documentContext.js
@@ -232,7 +232,7 @@ describe('DocumentContext', function() {
 			assert.equal(page, pc.pages[pc.pages.length - 1]);
 		});
 
-		it('should set y and availableHeight to initial values', function() {
+		it('should set y, availableHeight and availableWidth to initial values', function() {
 			pc.y = 123;
 			pc.availableHeight = 123;
 
@@ -240,6 +240,7 @@ describe('DocumentContext', function() {
 
 			assert.equal(pc.y, 60);
 			assert.equal(pc.availableHeight, 800 - 60 - 60);
+			assert.equal(pc.availableWidth, 400 - 40 - 40);
 		});
 	});
 

--- a/tests/documentContext.js
+++ b/tests/documentContext.js
@@ -6,7 +6,7 @@ describe('DocumentContext', function() {
 	var pc;
 
 	beforeEach(function() {
-		pc = new DocumentContext({ width: 400, height: 800 }, { left: 40, right: 40, top: 60, bottom: 60 });
+		pc = new DocumentContext({ width: 400, height: 800, orientation: 'portrait' }, { left: 40, right: 40, top: 60, bottom: 60 });
 		// pc.addPage();
 	});
 
@@ -219,6 +219,30 @@ describe('DocumentContext', function() {
 		});
 	});
 
+	describe('moveToNext page', function(){
+
+		it('should add new page in portrait', function () {
+			pc.moveToNextPage();
+
+			assert.equal(pc.pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pc.pages[1].pageSize.orientation, 'portrait');
+		});
+
+		it('should add a new page in the same orientation as the previous one', function () {
+			pc.moveToNextPage('landscape');
+			pc.moveToNextPage();
+			pc.moveToNextPage('portrait');
+			pc.moveToNextPage();
+
+			assert.equal(pc.pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pc.pages[1].pageSize.orientation, 'landscape');
+			assert.equal(pc.pages[2].pageSize.orientation, 'landscape');
+			assert.equal(pc.pages[3].pageSize.orientation, 'portrait');
+			assert.equal(pc.pages[4].pageSize.orientation, 'portrait');
+		});
+		
+	});
+	
 	describe('addPage', function() {
 		
 		var pageSize;
@@ -233,6 +257,7 @@ describe('DocumentContext', function() {
 
 			assert.equal(pc.pages.length, 2);
 		});
+		
 
 		it('should return added page', function() {
 			var page = pc.addPage(pageSize);

--- a/tests/elementWriter.js
+++ b/tests/elementWriter.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var ElementWriter = require('../src/elementWriter');
 
 describe('ElementWriter', function() {
-	var ew, ctx, page;
+	var ew, ctx, page, tracker;
 
 	beforeEach(function() {
 		page = { items: [] };
@@ -18,7 +18,8 @@ describe('ElementWriter', function() {
 				ctx.availableHeight -= offset;
 			}
 		};
-		ew = new ElementWriter(ctx);
+		tracker = {emit: function() {}};
+		ew = new ElementWriter(ctx, tracker);
 
 	});
 

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1142,6 +1142,7 @@ describe('LayoutBuilder', function() {
 				},
 				{
 					text: 'Page 2, landscape',
+          pageBreak: 'before',
 					pageOrientation: 'landscape'
 				}];
 
@@ -1152,25 +1153,6 @@ describe('LayoutBuilder', function() {
 			assert.equal(pages[1].pageSize.orientation, 'landscape');
 		});
 
-		it('should support combinations of page breaks and page orientation changes', function () {
-			var desc = [
-				{
-					text: 'Page 1, document orientation or default portrait'
-				},
-				{
-					pageBreak: 'before',
-					text: 'Page 3, landscape',
-					pageOrientation: 'landscape'
-				}];
-
-			var pages = builder.layoutDocument(desc, sampleTestProvider);
-
-			assert.equal(pages.length, 3);
-			assert.equal(pages[1].pageSize.orientation, 'portrait');
-			assert.equal(pages[2].pageSize.orientation, 'landscape');
-		});
-
-
 		it('should support changing the page orientation to landscape consecutively', function () {
 			var desc = [
 				{
@@ -1178,10 +1160,12 @@ describe('LayoutBuilder', function() {
 				},
 				{
 					text: 'Page 2, landscape',
+          pageBreak: 'before',
 					pageOrientation: 'landscape'
 				},
 				{
 					text: 'Page 3, landscape again',
+          pageBreak: 'after',
 					pageOrientation: 'landscape'
 				}
 			];

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1172,6 +1172,30 @@ describe('LayoutBuilder', function() {
 		});
 
 
+		it('should support changing the page orientation to landscape consecutively', function () {
+			var desc = [
+				{
+					text: 'Page 1, document orientation or default portrait'
+				},
+				{
+					text: 'Page 2, landscape',
+					pageOrientation: 'landscape'
+				},
+				{
+					text: 'Page 3, landscape again',
+					pageOrientation: 'landscape'
+				}
+			];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 3);
+			assert.equal(pages[0].pageOrientation, undefined);
+			assert.equal(pages[1].pageOrientation, 'landscape');
+			assert.equal(pages[2].pageOrientation, 'landscape');
+		});
+
+
 		it('should support images');
 		it('should align image properly');
 		it('should break pages if image cannot fit on current page');

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1135,6 +1135,43 @@ describe('LayoutBuilder', function() {
 			);
 		});
 
+		it('should support a switch of page orientation within a document', function () {
+			var defaultDocumentOrientation = undefined;
+			var desc = [
+				{
+					text: 'Page 1, document orientation or default portrait'
+				},
+				{
+					text: 'Page 2, landscape',
+					pageOrientation: 'landscape'
+				}];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 2);
+			assert.equal(pages[0].pageOrientation, defaultDocumentOrientation);
+			assert.equal(pages[1].pageOrientation, 'landscape');
+		});
+
+		it('should support combinations of page breaks and page orientation changes', function () {
+			var desc = [
+				{
+					text: 'Page 1, document orientation or default portrait'
+				},
+				{
+					pageBreak: 'before',
+					text: 'Page 3, landscape',
+					pageOrientation: 'landscape'
+				}];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 3);
+			assert.equal(pages[1].pageOrientation, undefined);
+			assert.equal(pages[2].pageOrientation, 'landscape');
+		});
+
+
 		it('should support images');
 		it('should align image properly');
 		it('should break pages if image cannot fit on current page');
@@ -1168,7 +1205,6 @@ describe('LayoutBuilder', function() {
 			it.skip('should support current page number');
 			it.skip('should support images');
 			it.skip('should support image scaling');
-			it.skip('should support various page orientations');
 			it.skip('should support various page sizes');
 
 			// DOING

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -46,7 +46,7 @@ describe('LayoutBuilder', function() {
 	var builder;
 
 	beforeEach(function() {
-		builder = new LayoutBuilder({ width: 400, height: 800 }, { left: 40, right: 40, top: 40, bottom: 40 });
+		builder = new LayoutBuilder({ width: 400, height: 800, orientation: 'portrait' }, { left: 40, right: 40, top: 40, bottom: 40 });
 		builder.pages = [];
 		builder.context = [ { page: -1, availableWidth: 320, availableHeight: 0 }];
 		builder.styleStack = new StyleContextStack();
@@ -1136,7 +1136,6 @@ describe('LayoutBuilder', function() {
 		});
 
 		it('should support a switch of page orientation within a document', function () {
-			var defaultDocumentOrientation = undefined;
 			var desc = [
 				{
 					text: 'Page 1, document orientation or default portrait'
@@ -1149,8 +1148,8 @@ describe('LayoutBuilder', function() {
 			var pages = builder.layoutDocument(desc, sampleTestProvider);
 
 			assert.equal(pages.length, 2);
-			assert.equal(pages[0].pageOrientation, defaultDocumentOrientation);
-			assert.equal(pages[1].pageOrientation, 'landscape');
+			assert.equal(pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pages[1].pageSize.orientation, 'landscape');
 		});
 
 		it('should support combinations of page breaks and page orientation changes', function () {
@@ -1167,8 +1166,8 @@ describe('LayoutBuilder', function() {
 			var pages = builder.layoutDocument(desc, sampleTestProvider);
 
 			assert.equal(pages.length, 3);
-			assert.equal(pages[1].pageOrientation, undefined);
-			assert.equal(pages[2].pageOrientation, 'landscape');
+			assert.equal(pages[1].pageSize.orientation, 'portrait');
+			assert.equal(pages[2].pageSize.orientation, 'landscape');
 		});
 
 
@@ -1190,9 +1189,9 @@ describe('LayoutBuilder', function() {
 			var pages = builder.layoutDocument(desc, sampleTestProvider);
 
 			assert.equal(pages.length, 3);
-			assert.equal(pages[0].pageOrientation, undefined);
-			assert.equal(pages[1].pageOrientation, 'landscape');
-			assert.equal(pages[2].pageOrientation, 'landscape');
+			assert.equal(pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pages[1].pageSize.orientation, 'landscape');
+			assert.equal(pages[2].pageSize.orientation, 'landscape');
 		});
 
 
@@ -1304,7 +1303,7 @@ describe('LayoutBuilder', function() {
 		}
 
 		beforeEach(function() {
-			var pageSize = { width: 400, height: 800 };
+			var pageSize = { width: 400, height: 800, orientation: 'portrait' };
 			var pageMargins = { left: 40, top: 40, bottom: 40, right: 40};
 
 			builder2 = new LayoutBuilder(pageSize, pageMargins, {});

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -279,12 +279,25 @@ describe('PageElementWriter', function() {
 
 		it('should switch width and height if page changes from landscape to portrait', function() {
 			ctx.pageOrientation = 'landscape';
+			ctx.pageSize.width = DOCUMENT_WIDTH;
+			ctx.pageSize.height = DOCUMENT_HEIGHT;
 			addOneTenthLines(6);
 			pew.moveToNextPage('portrait');
 
 			assert.equal(ctx.pages.length, 2);
-			assert.equal(ctx.pageSize.width, DOCUMENT_WIDTH);
-			assert.equal(ctx.pageSize.height, DOCUMENT_HEIGHT);
+			assert.equal(ctx.pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.pageSize.height, DOCUMENT_WIDTH);
+		});
+
+		it('should not switch width and height if page changes from landscape to landscape', function() {
+			ctx.pageOrientation = undefined;
+			addOneTenthLines(6);
+			pew.moveToNextPage('landscape');
+			pew.moveToNextPage('landscape');
+
+			assert.equal(ctx.pages.length, 3);
+			assert.equal(ctx.pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.pageSize.height, DOCUMENT_WIDTH);
 		});
 	});
 });

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -7,6 +7,9 @@ describe('PageElementWriter', function() {
 	var pew;
 	var ctx;
 
+	var DOCUMENT_WIDTH = 400;
+	var DOCUMENT_HEIGHT = 800;
+
 	function buildLine(height, alignment, x, y) {
 		return {
 			getHeight: function() { return height; },
@@ -48,9 +51,8 @@ describe('PageElementWriter', function() {
         });
 		return rep;
 	}
-
 	beforeEach(function() {
-		ctx = new DocumentContext({ width: 400, height: 800 }, { left: 40, right: 40, top: 60, bottom: 60 });
+		ctx = new DocumentContext({ width: DOCUMENT_WIDTH, height: DOCUMENT_HEIGHT }, { left: 40, right: 40, top: 60, bottom: 60 });
 		pew = new PageElementWriter(ctx);
 	});
 
@@ -261,6 +263,28 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages[1].items[1].item.y, 60 + 50);
 			assert(!ctx.pages[1].items[2].item.marker);
 			assert.equal(ctx.pages[1].items[2].item.y, 60 + 50 + 60);
+		});
+
+		it('should switch width and height if page changes from portrait to landscape', function() {
+			addOneTenthLines(6);
+			assert.equal(ctx.pageSize.width, DOCUMENT_WIDTH);
+			assert.equal(ctx.pageSize.height, DOCUMENT_HEIGHT);
+
+			pew.moveToNextPage('landscape');
+
+			assert.equal(ctx.pages.length, 2);
+			assert.equal(ctx.pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.pageSize.height, DOCUMENT_WIDTH);
+		});
+
+		it('should switch width and height if page changes from landscape to portrait', function() {
+			ctx.pageOrientation = 'landscape';
+			addOneTenthLines(6);
+			pew.moveToNextPage('portrait');
+
+			assert.equal(ctx.pages.length, 2);
+			assert.equal(ctx.pageSize.width, DOCUMENT_WIDTH);
+			assert.equal(ctx.pageSize.height, DOCUMENT_HEIGHT);
 		});
 	});
 });

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -7,8 +7,19 @@ describe('PageElementWriter', function() {
 	var pew;
 	var ctx;
 
-	var DOCUMENT_WIDTH = 400;
-	var DOCUMENT_HEIGHT = 800;
+	var DOCUMENT_WIDTH = 600;
+	var DOCUMENT_HEIGHT = 1100;
+
+
+	var MARGINS = {
+		left: 40,
+		right: 60,
+		top: 30,
+		bottom: 70
+	};
+
+	AVAILABLE_HEIGHT = 1000;
+	AVAILABLE_WIDTH = 500;
 
 	function buildLine(height, alignment, x, y) {
 		return {
@@ -33,7 +44,7 @@ describe('PageElementWriter', function() {
 
 	function addOneTenthLines(count) {
 		for(var i = 0; i < count; i++) {
-			var line = buildLine((800-60-60)/10);
+			var line = buildLine(AVAILABLE_HEIGHT/10);
 			pew.addLine(line);
 		}
 	}
@@ -52,7 +63,7 @@ describe('PageElementWriter', function() {
 		return rep;
 	}
 	beforeEach(function() {
-		ctx = new DocumentContext({ width: DOCUMENT_WIDTH, height: DOCUMENT_HEIGHT }, { left: 40, right: 40, top: 60, bottom: 60 });
+		ctx = new DocumentContext({ width: DOCUMENT_WIDTH, height: DOCUMENT_HEIGHT }, MARGINS);
 		pew = new PageElementWriter(ctx);
 	});
 
@@ -74,8 +85,8 @@ describe('PageElementWriter', function() {
 		it('should subtract line height from availableHeight when adding a line and update current y position', function() {
 			pew.addLine(buildLine(40));
 
-			assert.equal(ctx.y, 60 + 40);
-			assert.equal(ctx.availableHeight, 800 - 60 - 60 - 40);
+			assert.equal(ctx.y, MARGINS.top + 40);
+			assert.equal(ctx.availableHeight, AVAILABLE_HEIGHT - 40);
 		});
 
 		it('should add repeatable fragments if they exist and a new page is created before adding the line', function() {
@@ -169,10 +180,10 @@ describe('PageElementWriter', function() {
 
 			pew.commitUnbreakableBlock();
 
-			assert.equal(ctx.pages[1].items[0].item.x, 40);
-			assert.equal(ctx.pages[1].items[0].item.y, 60);
-			assert.equal(ctx.pages[1].items[1].item.x, 40);
-			assert.equal(ctx.pages[1].items[1].item.y, 60 + ctx.pages[1].items[0].item.getHeight());
+			assert.equal(ctx.pages[1].items[0].item.x, MARGINS.left);
+			assert.equal(ctx.pages[1].items[0].item.y, MARGINS.top);
+			assert.equal(ctx.pages[1].items[1].item.x, MARGINS.left);
+			assert.equal(ctx.pages[1].items[1].item.y, MARGINS.top + AVAILABLE_HEIGHT/10);
 		});
 
 		it('should add lines below any repeatable fragments if they exist and a new page is created', function() {
@@ -190,8 +201,8 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages.length, 2);
 			assert.equal(ctx.pages[1].items[0].item.marker, 'rep');
 			assert.equal(ctx.pages[1].items[1].item.marker, 'another');
-			assert.equal(ctx.pages[1].items[1].item.x, 40);
-			assert.equal(ctx.pages[1].items[1].item.y, 60 + 50);
+			assert.equal(ctx.pages[1].items[1].item.x, MARGINS.left);
+			assert.equal(ctx.pages[1].items[1].item.y, MARGINS.top + 50);
 		});
 
 		it('should make all further calls to addLine add lines again to the page when transaction finishes', function() {
@@ -244,9 +255,9 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages[1].items[0].item.marker, 'rep');
 			assert.equal(ctx.pages[1].items[1].item.marker, 'rep');
 			assert.equal(ctx.pages[1].items[2].item.marker, 'rep');
-			assert.equal(ctx.pages[1].items[2].item.y, 60 + 2 * 68);
+			assert.equal(ctx.pages[1].items[2].item.y, MARGINS.top + 2 * AVAILABLE_HEIGHT/10);
 			assert(!ctx.pages[1].items[3].item.marker);
-			assert.equal(ctx.pages[1].items[3].item.y, ctx.pages[1].items[2].item.y + 68);
+			assert.equal(ctx.pages[1].items[3].item.y, ctx.pages[1].items[2].item.y + AVAILABLE_HEIGHT/10);
 		});
 
 		it('should add repeatable fragments in the same order they have been added to the repeatable fragments collection', function() {
@@ -258,11 +269,11 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages.length, 2);
 			assert.equal(ctx.pages[1].items.length, 3);
 			assert.equal(ctx.pages[1].items[0].item.marker, 'rep1');
-			assert.equal(ctx.pages[1].items[0].item.y, 60);
+			assert.equal(ctx.pages[1].items[0].item.y, MARGINS.top);
 			assert.equal(ctx.pages[1].items[1].item.marker, 'rep2');
-			assert.equal(ctx.pages[1].items[1].item.y, 60 + 50);
+			assert.equal(ctx.pages[1].items[1].item.y, MARGINS.top + 50);
 			assert(!ctx.pages[1].items[2].item.marker);
-			assert.equal(ctx.pages[1].items[2].item.y, 60 + 50 + 60);
+			assert.equal(ctx.pages[1].items[2].item.y, MARGINS.top + 50 + 60);
 		});
 
 		it('should switch width and height if page changes from portrait to landscape', function() {

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -5,10 +5,11 @@ var DocumentContext = require('../src/documentContext');
 var PageElementWriter = require('../src/pageElementWriter');
 
 describe('PageElementWriter', function() {
-	var pew, ctx, tracker;
+	var pew, ctx, tracker, pageSize;
 
 	var DOCUMENT_WIDTH = 600;
 	var DOCUMENT_HEIGHT = 1100;
+	var DOCUMENT_ORIENTATION = 'portrait';
 
 
 	var MARGINS = {
@@ -63,7 +64,8 @@ describe('PageElementWriter', function() {
 		return rep;
 	}
 	beforeEach(function() {
-		ctx = new DocumentContext({ width: DOCUMENT_WIDTH, height: DOCUMENT_HEIGHT }, MARGINS);
+		pageSize = {width: DOCUMENT_WIDTH, height: DOCUMENT_HEIGHT, orientation: DOCUMENT_ORIENTATION};
+    ctx = new DocumentContext(pageSize, MARGINS);
 		tracker = { emit: sinon.spy() };
 		pew = new PageElementWriter(ctx, tracker);
 	});
@@ -273,7 +275,8 @@ describe('PageElementWriter', function() {
 			pew.pushToRepeatables(rep);
 			pew.commitUnbreakableBlock();
 
-			ctx.pages.push({items: []});
+
+      ctx.pages.push({items: [], pageSize: pageSize});
 
 			addOneTenthLines(2);
 
@@ -300,26 +303,30 @@ describe('PageElementWriter', function() {
 
 		it('should switch width and height if page changes from portrait to landscape', function() {
 			addOneTenthLines(6);
-			assert.equal(ctx.pageSize.width, DOCUMENT_WIDTH);
-			assert.equal(ctx.pageSize.height, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, DOCUMENT_ORIENTATION);
 
 			pew.moveToNextPage('landscape');
 
 			assert.equal(ctx.pages.length, 2);
-			assert.equal(ctx.pageSize.width, DOCUMENT_HEIGHT);
-			assert.equal(ctx.pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, 'landscape');
 		});
 
 		it('should switch width and height if page changes from landscape to portrait', function() {
-			ctx.pageOrientation = 'landscape';
-			ctx.pageSize.width = DOCUMENT_WIDTH;
-			ctx.pageSize.height = DOCUMENT_HEIGHT;
+			ctx.getCurrentPage().pageSize.orientation = 'landscape';
+			ctx.getCurrentPage().pageSize.width = DOCUMENT_WIDTH;
+			ctx.getCurrentPage().pageSize.height = DOCUMENT_HEIGHT;
+			
 			addOneTenthLines(6);
 			pew.moveToNextPage('portrait');
 
 			assert.equal(ctx.pages.length, 2);
-			assert.equal(ctx.pageSize.width, DOCUMENT_HEIGHT);
-			assert.equal(ctx.pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, 'portrait');
 		});
 
 		it('should not switch width and height if page changes from landscape to landscape', function() {
@@ -329,8 +336,9 @@ describe('PageElementWriter', function() {
 			pew.moveToNextPage('landscape');
 
 			assert.equal(ctx.pages.length, 3);
-			assert.equal(ctx.pageSize.width, DOCUMENT_HEIGHT);
-			assert.equal(ctx.pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, 'landscape');
 		});
 
 		it('should create new page', function () {
@@ -347,7 +355,7 @@ describe('PageElementWriter', function() {
 
 		it('should use existing page', function () {
 			addOneTenthLines(1);
-			ctx.pages.push({});
+			ctx.pages.push({items: [], pageSize: pageSize});
 			ctx.availableWidth = 'garbage';
 			ctx.availableHeight = 'garbage';
 

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -41,8 +41,7 @@ describe('Printer', function () {
     assert(Pdfkit.prototype.addPage.callCount === 2);
 
     assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], LONG_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], SHORT_SIDE);
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
   });
 
   it('should pass switched width and height to pdfkit if page orientation changes from portrait to landscape', function () {
@@ -65,8 +64,7 @@ describe('Printer', function () {
     assert(Pdfkit.prototype.addPage.callCount === 2);
 
     assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], LONG_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], SHORT_SIDE);
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
   });
 
   it('should pass switched width and height to pdfkit if page orientation changes from landscape to portrait', function () {
@@ -94,10 +92,8 @@ describe('Printer', function () {
     assert(Pdfkit.prototype.addPage.callCount === 3);
 
     assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], SHORT_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], LONG_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[0], SHORT_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[1], LONG_SIDE);
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [SHORT_SIDE, LONG_SIDE]);
+    assert.deepEqual(Pdfkit.prototype.addPage.thirdCall.args[0].size, [SHORT_SIDE, LONG_SIDE]);
   });
 
 
@@ -127,10 +123,8 @@ describe('Printer', function () {
 
 
     assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], LONG_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], SHORT_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[0], LONG_SIDE);
-    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[1], SHORT_SIDE);
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
+    assert.deepEqual(Pdfkit.prototype.addPage.thirdCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
   });
 
 });

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -1,0 +1,103 @@
+/*global _ */
+/*jshint globalstrict:true*/
+'use strict';
+
+var assert = require('assert');
+var Printer = require('../src/printer.js');
+var sinon = require('sinon');
+var Pdfkit = require('pdfkit');
+
+describe('Printer', function () {
+
+  var SHORT_SIDE = 100, LONG_SIDE = 200;
+  var fontDescriptors, printer;
+
+  beforeEach(function() {
+    fontDescriptors = {
+      Roboto: {
+        normal: 'examples/fonts/Roboto-Regular.ttf'
+      }
+    };
+    Pdfkit.prototype.addPage = sinon.spy(Pdfkit.prototype.addPage);
+
+  });
+
+  it('should pass switched width and height to pdfkit if page orientation changes from default portrait to landscape', function () {
+    printer = new Printer(fontDescriptors);
+    var docDefinition = {
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageOrientation: 'landscape'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    assert(Pdfkit.prototype.addPage.callCount === 2);
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], LONG_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], SHORT_SIDE);
+  });
+
+  it('should pass switched width and height to pdfkit if page orientation changes from portrait to landscape', function () {
+    printer = new Printer(fontDescriptors);
+    var docDefinition = {
+      pageOrientation: 'portrait',
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageOrientation: 'landscape'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    assert(Pdfkit.prototype.addPage.callCount === 2);
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], LONG_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], SHORT_SIDE);
+  });
+
+  it('should pass switched width and height to pdfkit if page orientation changes from landscape to portrait', function () {
+    printer = new Printer(fontDescriptors);
+
+    var docDefinition = {
+      pageOrientation: 'landscape',
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageOrientation: 'portrait'
+        },
+        {
+          text: 'Page 3 still portrait',
+          pageBreak: 'before'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    assert(Pdfkit.prototype.addPage.callCount === 3);
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], SHORT_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], LONG_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[0], SHORT_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[1], LONG_SIDE);
+  });
+
+});

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -9,7 +9,7 @@ var Pdfkit = require('pdfkit');
 
 describe('Printer', function () {
 
-  var SHORT_SIDE = 100, LONG_SIDE = 200;
+  var SHORT_SIDE = 1000, LONG_SIDE = 2000;
   var fontDescriptors, printer;
 
   beforeEach(function() {
@@ -98,6 +98,39 @@ describe('Printer', function () {
     assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], LONG_SIDE);
     assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[0], SHORT_SIDE);
     assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[1], LONG_SIDE);
+  });
+
+
+  it('should not switch width and height for pdfkit if page orientation changes from landscape to landscape', function () {
+    printer = new Printer(fontDescriptors);
+    var docDefinition = {
+      pageOrientation: 'portrait',
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageOrientation: 'landscape'
+        },
+        {
+          text: 'Page 3 landscape again',
+          pageOrientation: 'landscape'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    console.log('mysterious fourth call arguments', Pdfkit.prototype.addPage.lastCall.args);
+    assert.equal(Pdfkit.prototype.addPage.callCount, 3);
+
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[0], LONG_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.secondCall.args[0].size[1], SHORT_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[0], LONG_SIDE);
+    assert.equal(Pdfkit.prototype.addPage.thirdCall.args[0].size[1], SHORT_SIDE);
   });
 
 });

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -32,6 +32,7 @@ describe('Printer', function () {
         },
         {
           text: 'Page 2',
+          pageBreak: 'before',
           pageOrientation: 'landscape'
         }
       ]
@@ -55,6 +56,7 @@ describe('Printer', function () {
         },
         {
           text: 'Page 2',
+          pageBreak: 'before',
           pageOrientation: 'landscape'
         }
       ]
@@ -79,6 +81,7 @@ describe('Printer', function () {
         },
         {
           text: 'Page 2',
+          pageBreak: 'before',
           pageOrientation: 'portrait'
         },
         {
@@ -108,11 +111,13 @@ describe('Printer', function () {
         },
         {
           text: 'Page 2',
+          pageBreak: 'before',
           pageOrientation: 'landscape'
         },
         {
           text: 'Page 3 landscape again',
-          pageOrientation: 'landscape'
+          pageOrientation: 'landscape',
+          pageBreak: 'after'
         }
       ]
     };


### PR DESCRIPTION
* can set {text: '', pageOrientation: 'landscape'} property on any content element

Example usage: 

```javascript
var dd = {
	content: [
	    {
	        "text" : "Page 1 in portrait"
	    },
        {
            "text": "Page 2 and following pages in landscape",
            "pageOrientation": "landscape",
        },
        {
            "text": "Page 3 in landscape because I haven't changed the page orientation",
            "pageBreak": "before"
        },
        {   
            "text" : "Page 4 in portrait",
            "pageOrientation": "portrait"
        }
    ]
}
```

Will create 4 pages - pages 1 and 4 in portrait and pages 2 and 3 in landscape.
