### PR TITLE
Draw line and colums for single cell in a table

### DIFF
--- a/build/pdfmake.js
+++ b/build/pdfmake.js
@@ -20700,10 +20700,16 @@ TableProcessor.prototype.drawHorizontalLine = function(lineIndex, writer, overri
   if (lineWidth) {
     var offset = lineWidth / 2;
     var currentLine = null;
+     
+    if (this.tableNode.table.borderLines) {
+          var borderLines = this.tableNode.table.borderLines;
+      }
 
     for(var i = 0, l = this.rowSpanData.length; i < l; i++) {
       var data = this.rowSpanData[i];
       var shouldDrawLine = !data.rowSpan;
+        if(borderLines)
+            shouldDrawLine= borderLines[lineIndex][i] == 1;
 
       if (!currentLine && shouldDrawLine) {
         currentLine = { left: data.left, width: 0 };
@@ -20801,7 +20807,12 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
       }
 
       for(i = 0, l = xs.length; i < l; i++) {
-        this.drawVerticalLine(xs[i].x, y1 - hzLineOffset, y2 + this.bottomLineWidth, xs[i].index, writer);
+          var shouldDrawCol = true;
+              		if (this.tableNode.table.borderCols) {
+                  		  var borderCols = this.tableNode.table.borderCols;
+                  		  shouldDrawCol = borderCols[rowIndex][i] == 1;
+                  		}
+          if (shouldDrawCol) { this.drawVerticalLine(xs[i].x, y1 - hzLineOffset, y2 + this.bottomLineWidth, xs[i].index, writer); }
         if(i < l-1) {
           var colIndex = xs[i].index;
           var fillColor=  this.tableNode.table.body[rowIndex][colIndex].fillColor;


### PR DESCRIPTION
Based on this push : https://github.com/kafeg/pdfmake/commit/b77316e60dd67c17fa1fe89383744c0cbc0455b0

 Added two property in a table borderLine and borderCols

Example in a table of 2 row and 3 colums 0 for hide 1 to show 
table: {
                                          borderLines: [[0,1,0],[1,1,1],[1,1,1] ],
                                          borderCols:[[0,1,1,0],[1,1,1,1]], 
           body:[......]
...}

![image](https://cloud.githubusercontent.com/assets/152093/6229201/720bc06a-b6b5-11e4-8fc0-a48ced155e34.png)
