### PR TITLE
Several new features & bugfixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tab
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -438,6 +438,19 @@ If you set ```pageSize``` to a string, you can use one of the following values:
 * 'SRA0', 'SRA1', 'SRA2', 'SRA3', 'SRA4',
 * 'EXECUTIVE', 'FOLIO', 'LEGAL', 'LETTER', 'TABLOID'
 
+To change page orientation within a document, add a page break with the new page orientation.
+
+```js
+{
+  pageOrientation: 'portrait',
+  content: [
+    {text: 'Text on Portrait'},
+    {text: 'Text on Landscape', pageOrientation: 'landscape', pageBreak: 'before'},
+    {text: 'Text on Landscape 2', pageOrientation: 'portrait', pageBreak: 'after'},
+    {text: 'Text on Portrait 2'},
+  ]
+}
+```
 
 ## Coming soon
 Hmmm... let me know what you need ;)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "tests"
   },
   "dependencies": {
-    "pdfkit": "~0.7.0"
+    "pdfkit": "~0.7.0",
+    "lodash": "~3.1.0",
+		"lodash-node": "~3.1.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "grunt-browserify": "~1.3.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-dump-dir": "~0.1.2",
-    "grunt-contrib-concat": "~0.3.0"
+    "grunt-contrib-concat": "~0.3.0",
+    "sinon": "~1.12.2"
   },
   "scripts": {
     "test": "grunt test"

--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -34,9 +34,16 @@ Document.prototype._createDoc = function(options, callback) {
 	});
 	doc.on('end', function() {
 		result = Buffer.concat(chunks);
-		callback(result);
+		callback(result, doc._pdfMakePages);
 	});
 	doc.end();
+};
+
+Document.prototype._getPages = function(options, cb){
+  if (!cb) throw 'getBuffer is an async method and needs a callback argument';
+  this._createDoc(options, function(ignoreBuffer, pages){
+    cb(pages);
+  });
 };
 
 Document.prototype.open = function(message) {
@@ -104,7 +111,9 @@ Document.prototype.getDataUrl = function(cb, options) {
 
 Document.prototype.getBuffer = function(cb, options) {
 	if (!cb) throw 'getBuffer is an async method and needs a callback argument';
-	this._createDoc(options, cb);
+	this._createDoc(options, function(buffer){
+    cb(buffer);
+  });
 };
 
 module.exports = {

--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -218,11 +218,10 @@ DocMeasure.prototype.buildMarker = function(isOrderedList, counter, styleStack, 
 	else {
 		// TODO: ascender-based calculations
 		var radius = gapSize.fontSize / 6;
-
 		marker = {
 			canvas: [ {
 				x: radius,
-				y: gapSize.height + gapSize.decender - gapSize.fontSize / 3,//0,// gapSize.fontSize * 2 / 3,
+				y: (gapSize.height / gapSize.lineHeight) + gapSize.decender - gapSize.fontSize / 3,//0,// gapSize.fontSize * 2 / 3,
 				r1: radius,
 				r2: radius,
 				type: 'ellipse',

--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -79,32 +79,70 @@ DocMeasure.prototype.measureNode = function(node) {
 	}
 
 	function getNodeMargin() {
-		var margin = node.margin;
 
-		if (!margin && node.style) {
-			var styleArray = (node.style instanceof Array) ? node.style : [ node.style ];
+		function processSingleMargins(node, currentMargin){
+			if (node.marginLeft || node.marginTop || node.marginRight || node.marginBottom) {
+				return [
+					node.marginLeft || currentMargin[0] || 0,
+					node.marginTop || currentMargin[1] || 0,
+					node.marginRight || currentMargin[2]  || 0,
+					node.marginBottom || currentMargin[3]  || 0
+				];
+			}
+			return currentMargin;
+		}
 
-			for(var i = styleArray.length - 1; i >= 0; i--) {
+		function flattenStyleArray(styleArray){
+			var flattenedStyles = {};
+			for (var i = styleArray.length - 1; i >= 0; i--) {
 				var styleName = styleArray[i];
 				var style = self.styleStack.styleDictionary[styleName];
-				if (style && style.margin) {
-					margin = style.margin;
-					break;
+				for(var key in style){
+					if(style.hasOwnProperty(key)){
+						flattenedStyles[key] = style[key];
+					}
 				}
 			}
+			return flattenedStyles;
 		}
 
-		if (!margin) return null;
+		function convertMargin(margin) {
+			if (typeof margin === 'number' || margin instanceof Number) {
+				margin = [ margin, margin, margin, margin ];
+			} else if (margin instanceof Array) {
+				if (margin.length === 2) {
+					margin = [ margin[0], margin[1], margin[0], margin[1] ];
+				}
+			}
+			return margin;
+		}
 
-		if (typeof margin === 'number' || margin instanceof Number) {
-			margin = [ margin, margin, margin, margin ];
-		} else if (margin instanceof Array) {
-			if (margin.length === 2) {
-				margin = [ margin[0], margin[1], margin[0], margin[1] ];
+		var margin = [undefined, undefined, undefined, undefined];
+
+		if(node.style) {
+			var styleArray = (node.style instanceof Array) ? node.style : [node.style];
+			var flattenedStyleArray = flattenStyleArray(styleArray);
+
+			if(flattenedStyleArray) {
+				margin = processSingleMargins(flattenedStyleArray, margin);
+			}
+
+			if(flattenedStyleArray.margin){
+				margin = convertMargin(flattenedStyleArray.margin);
 			}
 		}
+		
+		margin = processSingleMargins(node, margin);
 
-		return margin;
+		if(node.margin){
+			margin = convertMargin(node.margin);
+		}
+
+		if(margin[0] === undefined && margin[1] === undefined && margin[2] === undefined && margin[3] === undefined) {
+			return null;
+		} else {
+			return margin;
+		}
 	}
 };
 

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -196,6 +196,30 @@ DocumentContext.prototype.getCurrentPage = function() {
 	return this.pages[this.page];
 };
 
+DocumentContext.prototype.getCurrentPosition = function() {
+  var pageSize = this.getCurrentPage().pageSize || this.pageSize;
+  var innerHeight = pageSize.height - this.pageMargins.top - this.pageMargins.bottom;
+  var innerWidth = pageSize.width - this.pageMargins.left - this.pageMargins.right;
+
+  return {
+    pageNumber: this.page + 1,
+    left: this.x,
+    top: this.y,
+    verticalRatio: ((this.y - this.pageMargins.top) / innerHeight),
+    horizontalRatio: ((this.x - this.pageMargins.left) / innerWidth)
+  };
+};
+
+
+DocumentContext.prototype.setDefaultPage = function(defaultPage) {
+    // copy the items without deep-copying the object (which is not possible due to circular structures)
+    this.defaultPage = { items: (defaultPage || this.pages[this.page]).items.slice() };
+};
+
+DocumentContext.prototype.getDefaultPage = function() {
+    return { items: this.defaultPage.items.slice() };
+};
+
 function bottomMostContext(c1, c2) {
 	var r;
 

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -197,27 +197,18 @@ DocumentContext.prototype.getCurrentPage = function() {
 };
 
 DocumentContext.prototype.getCurrentPosition = function() {
-  var pageSize = this.getCurrentPage().pageSize || this.pageSize;
+  var pageSize = this.getCurrentPage().pageSize;
   var innerHeight = pageSize.height - this.pageMargins.top - this.pageMargins.bottom;
   var innerWidth = pageSize.width - this.pageMargins.left - this.pageMargins.right;
 
   return {
     pageNumber: this.page + 1,
+    pageOrientation: pageSize.orientation,
     left: this.x,
     top: this.y,
     verticalRatio: ((this.y - this.pageMargins.top) / innerHeight),
     horizontalRatio: ((this.x - this.pageMargins.left) / innerWidth)
   };
-};
-
-
-DocumentContext.prototype.setDefaultPage = function(defaultPage) {
-    // copy the items without deep-copying the object (which is not possible due to circular structures)
-    this.defaultPage = { items: (defaultPage || this.pages[this.page]).items.slice() };
-};
-
-DocumentContext.prototype.getDefaultPage = function() {
-    return { items: this.defaultPage.items.slice() };
 };
 
 function bottomMostContext(c1, c2) {

--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -27,7 +27,8 @@ function addPageItem(page, item, index) {
 ElementWriter.prototype.addLine = function(line, dontUpdateContextPosition, index) {
 	var height = line.getHeight();
 	var context = this.context;
-	var page = context.getCurrentPage();
+	var page = context.getCurrentPage(),
+      position = this.getCurrentPositionOnPage();
 
 	if (context.availableHeight < height || !page) {
 		return false;
@@ -46,7 +47,7 @@ ElementWriter.prototype.addLine = function(line, dontUpdateContextPosition, inde
 
 	if (!dontUpdateContextPosition) context.moveDown(height);
 
-	return true;
+	return position;
 };
 
 ElementWriter.prototype.alignLine = function(line) {
@@ -85,7 +86,8 @@ ElementWriter.prototype.alignLine = function(line) {
 
 ElementWriter.prototype.addImage = function(image, index) {
 	var context = this.context;
-	var page = context.getCurrentPage();
+	var page = context.getCurrentPage(),
+      position = this.getCurrentPositionOnPage();
 
 	if (context.availableHeight < image._height || !page) {
 		return false;
@@ -103,12 +105,13 @@ ElementWriter.prototype.addImage = function(image, index) {
 
 	context.moveDown(image._height);
 
-	return true;
+	return position;
 };
 
 ElementWriter.prototype.addQr = function(qr, index) {
 	var context = this.context;
-	var page = context.getCurrentPage();
+	var page = context.getCurrentPage(),
+      position = this.getCurrentPositionOnPage();
 
 	if (context.availableHeight < qr._height || !page) {
 		return false;
@@ -128,7 +131,7 @@ ElementWriter.prototype.addQr = function(qr, index) {
 
 	context.moveDown(qr._height);
 
-	return true;
+	return position;
 };
 
 ElementWriter.prototype.alignImage = function(image) {
@@ -151,7 +154,8 @@ ElementWriter.prototype.alignImage = function(image) {
 
 ElementWriter.prototype.addVector = function(vector, ignoreContextX, ignoreContextY, index) {
 	var context = this.context;
-	var page = context.getCurrentPage();
+	var page = context.getCurrentPage(),
+      position = this.getCurrentPositionOnPage();
 
 	if (page) {
 		offsetVector(vector, ignoreContextX ? 0 : context.x, ignoreContextY ? 0 : context.y);
@@ -159,7 +163,7 @@ ElementWriter.prototype.addVector = function(vector, ignoreContextX, ignoreConte
             type: 'vector',
             item: vector
         }, index);
-		return true;
+		return position;
 	}
 };
 
@@ -247,6 +251,10 @@ ElementWriter.prototype.pushContext = function(contextOrWidth, height) {
 
 ElementWriter.prototype.popContext = function() {
 	this.context = this.contextStack.pop();
+};
+
+ElementWriter.prototype.getCurrentPositionOnPage = function(){
+	return (this.contextStack[0] || this.context).getCurrentPosition();
 };
 
 

--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -13,7 +13,7 @@ var DocumentContext = require('./documentContext');
 function ElementWriter(context, tracker) {
 	this.context = context;
 	this.contextStack = [];
-	this.tracker = tracker || { emit: function() { } };
+	this.tracker = tracker;
 }
 
 function addPageItem(page, item, index) {
@@ -116,9 +116,9 @@ ElementWriter.prototype.addQr = function(qr, index) {
 
 	qr.x = context.x + (qr.x || 0);
 	qr.y = context.y;
-	
+
 	this.alignImage(qr);
-	
+
 	for (var i=0, l=qr._canvas.length; i < l; i++) {
 		var vector = qr._canvas[i];
 		vector.x += qr.x;
@@ -194,7 +194,7 @@ ElementWriter.prototype.addFragment = function(block, useBlockXOffset, useBlockY
                     item: l
                 });
                 break;
-                
+
             case 'vector':
                 var v = pack(item.item);
 
@@ -204,7 +204,7 @@ ElementWriter.prototype.addFragment = function(block, useBlockXOffset, useBlockY
                     item: v
                 });
                 break;
-                
+
             case 'image':
                 var img = pack(item.item);
 
@@ -233,7 +233,7 @@ ElementWriter.prototype.addFragment = function(block, useBlockXOffset, useBlockY
 */
 ElementWriter.prototype.pushContext = function(contextOrWidth, height) {
 	if (contextOrWidth === undefined) {
-		height = this.context.pageSize.height - this.context.pageMargins.top - this.context.pageMargins.bottom;
+		height = this.context.getCurrentPage().height - this.context.pageMargins.top - this.context.pageMargins.bottom;
 		contextOrWidth = this.context.availableWidth;
 	}
 

--- a/src/imageMeasure.js
+++ b/src/imageMeasure.js
@@ -1,5 +1,5 @@
 var pdfKit = require('pdfkit');
-var PDFImage = require('../node_modules/pdfkit/js/image');
+var PDFImage = require('pdfkit/js/image');
 
 function ImageMeasure(pdfDoc, imageDictionary) {
 	this.pdfDoc = pdfDoc;

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -77,11 +77,18 @@ LayoutBuilder.prototype.layoutDocument = function (docStructure, fontProvider, s
           return _.contains(node0.nodeInfo.pageNumbers, pageNumber);
         }).value();
 
+        var nodesOnNextPage = _.chain(followingNodeList).drop(index + 1).filter(function (node0) {
+          return _.contains(node0.nodeInfo.pageNumbers, pageNumber + 1);
+        }).value();
+
         var previousNodesOnPage = _.chain(followingNodeList).take(index).filter(function (node0) {
           return _.contains(node0.nodeInfo.pageNumbers, pageNumber);
         }).value();
 
-        if (pageBreakBeforeFct(node.nodeInfo, _.map(followingNodesOnPage, 'nodeInfo'), _.map(previousNodesOnPage, 'nodeInfo'))) {
+        if (pageBreakBeforeFct(node.nodeInfo,
+          _.map(followingNodesOnPage, 'nodeInfo'),
+          _.map(nodesOnNextPage, 'nodeInfo'),
+          _.map(previousNodesOnPage, 'nodeInfo'))) {
           node.pageBreak = 'before';
           return true;
         }

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -219,7 +219,7 @@ LayoutBuilder.prototype.addHeadersAndFooters = function(header, footer) {
   if(isFunction(footer)) {
     this.addDynamicRepeatable(footer, footerSizeFct);
   } else if(footer) {
-    this.addStaticRepeatable(footer, 0, headerSizeFct());
+    this.addStaticRepeatable(footer, headerSizeFct);
   }
 };
 

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -19,29 +19,35 @@ function PageElementWriter(context, tracker) {
 	this.writer = new ElementWriter(context, tracker);
 }
 
+function fitOnPage(self, addFct){
+  var position = addFct(self);
+  if (!position) {
+    self.moveToNextPage();
+    position = addFct(self);
+  }
+  return position;
+}
+
 PageElementWriter.prototype.addLine = function(line, dontUpdateContextPosition, index) {
-	if (!this.writer.addLine(line, dontUpdateContextPosition, index)) {
-		this.moveToNextPage();
-		this.writer.addLine(line, dontUpdateContextPosition, index);
-	}
+  return fitOnPage(this, function(self){
+    return self.writer.addLine(line, dontUpdateContextPosition, index);
+  });
 };
 
 PageElementWriter.prototype.addImage = function(image, index) {
-	if(!this.writer.addImage(image, index)) {
-		this.moveToNextPage();
-		this.writer.addImage(image, index);
-	}
+  return fitOnPage(this, function(self){
+    return self.writer.addImage(image, index);
+  });
 };
 
 PageElementWriter.prototype.addQr = function(qr, index) {
-	if(!this.writer.addQr(qr, index)) {
-		this.moveToNextPage();
-		this.writer.addQr(qr, index);
-	}
+  return fitOnPage(this, function(self){
+		return self.writer.addQr(qr, index);
+	});
 };
 
 PageElementWriter.prototype.addVector = function(vector, ignoreContextX, ignoreContextY, index) {
-	this.writer.addVector(vector, ignoreContextX, ignoreContextY, index);
+	return this.writer.addVector(vector, ignoreContextX, ignoreContextY, index);
 };
 
 PageElementWriter.prototype.addFragment = function(fragment, useBlockXOffset, useBlockYOffset, dontUpdateContextPosition) {

--- a/src/pageElementWriter.js
+++ b/src/pageElementWriter.js
@@ -51,33 +51,24 @@ PageElementWriter.prototype.addFragment = function(fragment, useBlockXOffset, us
 	}
 };
 
-PageElementWriter.prototype.moveToNextPage = function() {
-	var nextPageIndex = this.writer.context.page + 1;
-
-	var prevPage = this.writer.context.page;
-	var prevY = this.writer.context.y;
-
-	if (nextPageIndex >= this.writer.context.pages.length) {
-		// create new Page
-        this.writer.context.addPage();
-
-		// add repeatable fragments
+PageElementWriter.prototype.moveToNextPage = function(pageOrientation) {
+	
+	var nextPage = this.writer.context.moveToNextPage(pageOrientation);
+	
+  if (nextPage.newPageCreated) {
 		this.repeatables.forEach(function(rep) {
 			this.writer.addFragment(rep, true);
 		}, this);
 	} else {
-		this.writer.context.page = nextPageIndex;
-		this.writer.context.moveToPageTop();
-
 		this.repeatables.forEach(function(rep) {
 			this.writer.context.moveDown(rep.height);
 		}, this);
 	}
 
 	this.writer.tracker.emit('pageChanged', {
-		prevPage: prevPage,
-		prevY: prevY,
-		y: this.writer.context.y
+		prevPage: nextPage.prevPage,
+		prevY: nextPage.prevY,
+		y: nextPage.y
 	});
 };
 
@@ -104,15 +95,15 @@ PageElementWriter.prototype.commitUnbreakableBlock = function(forcedX, forcedY) 
 			if(nbPages > 1) {
 				// on out-of-context blocs (headers, footers, background) height should be the whole DocumentContext height
 				if (forcedX !== undefined || forcedY !== undefined) {
-					fragment.height = unbreakableContext.pageSize.height - unbreakableContext.pageMargins.top - unbreakableContext.pageMargins.bottom;
+					fragment.height = unbreakableContext.getCurrentPage().pageSize.height - unbreakableContext.pageMargins.top - unbreakableContext.pageMargins.bottom;
 				} else {
-					fragment.height = this.writer.context.pageSize.height - this.writer.context.pageMargins.top - this.writer.context.pageMargins.bottom;
+					fragment.height = this.writer.context.getCurrentPage().pageSize.height - this.writer.context.pageMargins.top - this.writer.context.pageMargins.bottom;
 					for (var i = 0, l = this.repeatables.length; i < l; i++) {
 						fragment.height -= this.repeatables[i].height;
 					}
 				}
 			} else {
-				fragment.height = unbreakableContext.y;	
+				fragment.height = unbreakableContext.y;
 			}
 
 			if (forcedX !== undefined || forcedY !== undefined) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -201,6 +201,7 @@ function StringObject(str){
 }
 
 function renderPages(pages, fontProvider, pdfKitDoc) {
+  pdfKitDoc._pdfMakePages = pages;
 	for(var i = 0, l = pages.length; i < l; i++) {
 		if (i > 0) {
 			pdfKitDoc.addPage();

--- a/src/printer.js
+++ b/src/printer.js
@@ -75,8 +75,9 @@ PdfPrinter.prototype.createPdfKitDocument = function(docDefinition, options) {
 	var pageSize = pageSize2widthAndHeight(docDefinition.pageSize || 'a4');
 
   if(docDefinition.pageOrientation === 'landscape') {
-    pageSize = { width: pageSize.height, height: pageSize.width };
+    pageSize = { width: pageSize.height, height: pageSize.width};
   }
+	pageSize.orientation = docDefinition.pageOrientation === 'landscape' ? docDefinition.pageOrientation : 'portrait';
 
 	this.pdfKitDoc = new PdfKit({ size: [ pageSize.width, pageSize.height ], compress: false});
 	this.pdfKitDoc.info.Producer = 'pdfmake';
@@ -200,11 +201,22 @@ function StringObject(str){
 	};
 }
 
+function updatePageOrientationInOptions(currentPage, pdfKitDoc) {
+	var previousPageOrientation = pdfKitDoc.options.size[0] > pdfKitDoc.options.size[1] ? 'landscape' : 'portrait';
+
+	if(currentPage.pageSize.orientation !== previousPageOrientation) {
+		var width = pdfKitDoc.options.size[0];
+		var height = pdfKitDoc.options.size[1];
+		pdfKitDoc.options.size = [height, width];
+	}
+}
+
 function renderPages(pages, fontProvider, pdfKitDoc) {
   pdfKitDoc._pdfMakePages = pages;
-	for(var i = 0, l = pages.length; i < l; i++) {
+	for (var i = 0; i < pages.length; i++) {
 		if (i > 0) {
-			pdfKitDoc.addPage();
+			updatePageOrientationInOptions(pages[i], pdfKitDoc);
+			pdfKitDoc.addPage(pdfKitDoc.options);
 		}
 
 		setFontRefs(fontProvider, pdfKitDoc);

--- a/src/printer.js
+++ b/src/printer.js
@@ -4,7 +4,7 @@
 
 var LayoutBuilder = require('./layoutBuilder');
 var PdfKit = require('pdfkit');
-var PDFReference = require('../node_modules/pdfkit/js/reference');
+var PDFReference = require('pdfkit/js/reference');
 var sizes = require('./standardPageSizes');
 var ImageMeasure = require('./imageMeasure');
 var textDecorator = require('./textDecorator');

--- a/src/printer.js
+++ b/src/printer.js
@@ -96,7 +96,7 @@ PdfPrinter.prototype.createPdfKitDocument = function(docDefinition, options) {
     builder.registerTableLayouts(options.tableLayouts);
   }
 
-	var pages = builder.layoutDocument(docDefinition.content, this.fontProvider, docDefinition.styles || {}, docDefinition.defaultStyle || { fontSize: 12, font: 'Roboto' }, docDefinition.background, docDefinition.header, docDefinition.footer, docDefinition.images, docDefinition.watermark);
+	var pages = builder.layoutDocument(docDefinition.content, this.fontProvider, docDefinition.styles || {}, docDefinition.defaultStyle || { fontSize: 12, font: 'Roboto' }, docDefinition.background, docDefinition.header, docDefinition.footer, docDefinition.images, docDefinition.watermark, docDefinition.pageBreakBefore);
 
 	renderPages(pages, this.fontProvider, this.pdfKitDoc);
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -410,7 +410,7 @@ FontProvider.prototype.provideFont = function(familyName, bold, italics) {
 	if (cached) return cached;
 
 	var fontCache = (this.cache[familyName] = this.cache[familyName] || {});
-	fontCache[type] = this.pdfDoc.font(this.fonts[familyName][type], familyName)._font;
+	fontCache[type] = this.pdfDoc.font(this.fonts[familyName][type], familyName + ' (' + type + ')')._font;
 	return fontCache[type];
 };
 

--- a/src/styleContextStack.js
+++ b/src/styleContextStack.js
@@ -93,7 +93,8 @@ StyleContextStack.prototype.autopush = function(item) {
 		'decoration',
 		'decorationStyle',
 		'decorationColor',
-		'background'
+		'background',
+		'lineHeight'
 		//'tableCellPadding'
 		// 'cellBorder',
 		// 'headerCellBorder',

--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -18,6 +18,7 @@ TableProcessor.prototype.beginTable = function(writer) {
 
   this.tableWidth = tableNode._offsets.total + getTableInnerContentWidth();
   this.rowSpanData = prepareRowSpanData();
+  this.cleanUpRepeatables = false;
 
   this.headerRows = tableNode.table.headerRows || 0;
   this.rowsWithoutPageBreak = this.headerRows + (tableNode.table.keepWithHeaderRows || 0);
@@ -143,7 +144,9 @@ TableProcessor.prototype.drawVerticalLine = function(x, y0, y1, vLineIndex, writ
 };
 
 TableProcessor.prototype.endTable = function(writer) {
-  writer.popFromRepeatables();
+  if (this.cleanUpRepeatables) {
+    writer.popFromRepeatables();
+  }
 };
 
 TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
@@ -264,6 +267,7 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
     if(this.headerRepeatable && (rowIndex === (this.rowsWithoutPageBreak - 1) || rowIndex === this.tableNode.table.body.length - 1)) {
       writer.commitUnbreakableBlock();
       writer.pushToRepeatables(this.headerRepeatable);
+      this.cleanUpRepeatables = true;
       this.headerRepeatable = null;
     }
 

--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -138,7 +138,7 @@ TableProcessor.prototype.drawVerticalLine = function(x, y0, y1, vLineIndex, writ
     y1: y0,
     y2: y1,
     lineWidth: width,
-    lineColor: typeof this.layout.vlineColor === 'function' ? this.layout.vLineColor(vLineIndex, this.tableNode) : this.layout.vLineColor
+    lineColor: typeof this.layout.vLineColor === 'function' ? this.layout.vLineColor(vLineIndex, this.tableNode) : this.layout.vLineColor
   }, false, true);
 };
 

--- a/src/textTools.js
+++ b/src/textTools.js
@@ -73,13 +73,15 @@ TextTools.prototype.sizeOfString = function(text, styleContextStack) {
 	var fontSize = getStyleProperty({}, styleContextStack, 'fontSize', 12);
 	var bold = getStyleProperty({}, styleContextStack, 'bold', false);
 	var italics = getStyleProperty({}, styleContextStack, 'italics', false);
+	var lineHeight = getStyleProperty({}, styleContextStack, 'lineHeight', 1);
 
 	var font = this.fontProvider.provideFont(fontName, bold, italics);
 
 	return {
 		width: font.widthOfString(removeDiacritics(text), fontSize),
-		height: font.lineHeight(fontSize),
+		height: font.lineHeight(fontSize) * lineHeight,
 		fontSize: fontSize,
+		lineHeight: lineHeight,
 		ascender: font.ascender / 1000 * fontSize,
 		decender: font.decender / 1000 * fontSize
 	};
@@ -210,12 +212,13 @@ function measure(fontProvider, textArray, styleContextStack) {
 		var decorationColor = getStyleProperty(item, styleContextStack, 'decorationColor', null);
 		var decorationStyle = getStyleProperty(item, styleContextStack, 'decorationStyle', null);
 		var background = getStyleProperty(item, styleContextStack, 'background', null);
+		var lineHeight = getStyleProperty(item, styleContextStack, 'lineHeight', 1);
 
 		var font = fontProvider.provideFont(fontName, bold, italics);
 
 		// TODO: character spacing
 		item.width = font.widthOfString(removeDiacritics(item.text), fontSize);
-		item.height = font.lineHeight(fontSize);
+		item.height = font.lineHeight(fontSize) * lineHeight;
 
 		var leadingSpaces = item.text.match(LEADING);
 		var trailingSpaces = item.text.match(TRAILING);

--- a/tests/docMeasure.js
+++ b/tests/docMeasure.js
@@ -41,7 +41,7 @@ describe('DocMeasure', function() {
 					called = true;
 					return { items: [ 'abc' ], minWidth: 1, maxWidth: 10 };
 				}
-			}
+			};
 
 			var result = dm.measureLeaf(node);
 			assert(called);
@@ -172,7 +172,7 @@ describe('DocMeasure', function() {
 					vLineWidth: function() { return 0; },
 					hLineWidth: function() { return 0; },
 					paddingLeft: function() { return 0; },
-					paddingRight: function() { return 0; },
+					paddingRight: function() { return 0; }
 				}
 			};
 		});
@@ -372,7 +372,79 @@ describe('DocMeasure', function() {
 		it('should scales image to fit whole picture in a rectangle if fit is specified');
 		it('should copy alignment from styleStack into image definition object');
 		it('should support dataUri images', function() {
-			
+
+		});
+	});
+
+	describe('measureDocument', function () {
+		it('should treat margin in styling properties with higher priority', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'marginStyle': {margin: 10}}, {});
+			var result = docMeasure.measureDocument({text: 'test', style:'marginStyle', margin:[5,5,5,5]});
+			assert.deepEqual(result._margin, [5, 5, 5, 5]);
+		});
+
+		it('should apply margins defined in the styles', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'topLevel': {margin: [123, 3, 5, 6]}}, {});
+			var result = docMeasure.measureDocument({text: 'test', style: 'topLevel'});
+			assert.deepEqual(result._margin, [123, 3, 5, 6]);
+		});
+
+		it('should apply sublevel styles not to parent', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'topLevel': {margin: [123, 3, 5, 6]}, 'subLevel': {margin: 5}}, {});
+			var result = docMeasure.measureDocument({ul: ['one', 'two', {text: 'three', style:'subLevel'}], style: 'topLevel'});
+			assert.deepEqual(result._margin, [123, 3, 5, 6]);
+			assert.equal(result.ul[0]._margin, null);
+			assert.equal(result.ul[1]._margin, null);
+			assert.deepEqual(result.ul[2]._margin, [5, 5, 5, 5]);
+		});
+
+		it('should apply subsublevel styles not to parent', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'topLevel': {margin: [123, 3, 5, 6]}, 'subLevel': {margin: 5}, 'subsubLevel': {margin: 25}}, {});
+			var result = docMeasure.measureDocument({ul: ['one', 'two', {text: 'three', style:'subLevel'}, {ol: [{text:'three A', style:'subsubLevel'}]}], style: 'topLevel'});
+			assert.deepEqual(result._margin, [123, 3, 5, 6]);
+			assert.equal(result.ul[0]._margin, null);
+			assert.equal(result.ul[1]._margin, null);
+			assert.deepEqual(result.ul[2]._margin, [5, 5, 5, 5]);
+			assert.deepEqual(result.ul[3].ol[0]._margin, [25, 25, 25, 25]);
+		});
+
+		it('should process marginLeft property if defined', function () {
+			var result = docMeasure.measureDocument({text: 'some text', marginLeft:5});
+				assert.deepEqual(result._margin, [5, 0, 0, 0]);
+		});
+
+		it('should process marginRight property if defined', function () {
+			var result = docMeasure.measureDocument({text: 'some text', marginRight:5});
+			assert.deepEqual(result._margin, [0, 0, 5, 0]);
+		});
+
+		it('should process multiple single margin properties if defined', function () {
+			var result = docMeasure.measureDocument({text: 'some text', marginRight:5, marginTop:10, marginBottom:2});
+			assert.deepEqual(result._margin, [0, 10, 5, 2]);
+		});
+
+		it('should treat margin property with higher priority than single margin properties', function () {
+			var result = docMeasure.measureDocument({text: 'some text', marginRight:5, marginTop:10, marginBottom:2, margin:12});
+			assert.deepEqual(result._margin, [12, 12, 12, 12]);
+		});
+
+		it('should combine all single margins defined in style dict ', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'style1': {marginLeft: 5}, 'style2': {marginTop: 10}}, {});
+			var result = docMeasure.measureDocument({text: 'some text', style:['style1', 'style2']});
+			assert.deepEqual(result._margin, [5, 10, 0, 0]);
+		});
+
+		it('should combine the single margin defined in style dict and the object itself', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'style1': {marginLeft: 5}}, {});
+			var result = docMeasure.measureDocument({text: 'some text', style:['style1'], marginRight: 15});
+			assert.deepEqual(result._margin, [5, 0, 15, 0]);
+		});
+
+		it('should override only left margin if marginLeft is defined', function () {
+			docMeasure = new DocMeasure(sampleTestProvider, {'topLevel': {margin: [123, 3, 5, 6]}, 'subLevel': {marginLeft: 5}}, {});
+			var result = docMeasure.measureDocument({ul: ['one', 'two', {text: 'three', style:'subLevel'}], style: 'topLevel'});
+			assert.deepEqual(result._margin, [123, 3, 5, 6]);
+			assert.deepEqual(result.ul[2]._margin, [5, 0, 0, 0]);
 		});
 	});
 });

--- a/tests/documentContext.js
+++ b/tests/documentContext.js
@@ -6,7 +6,7 @@ describe('DocumentContext', function() {
 	var pc;
 
 	beforeEach(function() {
-		pc = new DocumentContext({ width: 400, height: 800 }, { left: 40, right: 40, top: 60, bottom: 60 });
+		pc = new DocumentContext({ width: 400, height: 800, orientation: 'portrait' }, { left: 40, right: 40, top: 60, bottom: 60 });
 		// pc.addPage();
 	});
 
@@ -219,28 +219,74 @@ describe('DocumentContext', function() {
 		});
 	});
 
+	describe('moveToNext page', function(){
+
+		it('should add new page in portrait', function () {
+			pc.moveToNextPage();
+
+			assert.equal(pc.pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pc.pages[1].pageSize.orientation, 'portrait');
+		});
+
+		it('should add a new page in the same orientation as the previous one', function () {
+			pc.moveToNextPage('landscape');
+			pc.moveToNextPage();
+			pc.moveToNextPage('portrait');
+			pc.moveToNextPage();
+
+			assert.equal(pc.pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pc.pages[1].pageSize.orientation, 'landscape');
+			assert.equal(pc.pages[2].pageSize.orientation, 'landscape');
+			assert.equal(pc.pages[3].pageSize.orientation, 'portrait');
+			assert.equal(pc.pages[4].pageSize.orientation, 'portrait');
+		});
+		
+	});
+	
 	describe('addPage', function() {
+		
+		var pageSize;
+		
+		beforeEach(function(){
+			pageSize = {width: 200, height: 400, orientation: 'landscape'};
+		});
+		
 		it('should add a new page', function() {
-			pc.addPage();
+			
+      pc.addPage(pageSize);
 
 			assert.equal(pc.pages.length, 2);
 		});
+		
 
 		it('should return added page', function() {
-			var page = pc.addPage();
+			var page = pc.addPage(pageSize);
 
 			assert.equal(page, pc.pages[pc.pages.length - 1]);
 		});
 
-		it('should set y and availableHeight to initial values', function() {
+		it('should set y, availableHeight and availableWidth on page to initial values', function() {
 			pc.y = 123;
 			pc.availableHeight = 123;
 
-			pc.moveToPageTop();
+			pc.initializePage();
 
 			assert.equal(pc.y, 60);
 			assert.equal(pc.availableHeight, 800 - 60 - 60);
+			assert.equal(pc.availableWidth, 400 - 40 - 40);
 		});
+
+    it('should keep column width when in column group, but set page width', function() {
+      pc.beginColumnGroup();
+      pc.beginColumn(100, 0, {});
+      pc.initializePage();
+
+      assert.equal(pc.availableWidth, 100);
+
+      pc.completeColumnGroup();
+
+      assert.equal(pc.availableWidth, 400 - 40 - 40);
+    });
 	});
 
 	describe('bottomMostContext', function() {

--- a/tests/elementWriter.js
+++ b/tests/elementWriter.js
@@ -3,9 +3,10 @@ var assert = require('assert');
 var ElementWriter = require('../src/elementWriter');
 
 describe('ElementWriter', function() {
-	var ew, ctx, page, tracker;
+	var ew, ctx, page, tracker, fakePosition;
 
 	beforeEach(function() {
+    fakePosition = {fake: 'position'};
 		page = { items: [] };
 		ctx = {
 			x: 10,
@@ -13,6 +14,7 @@ describe('ElementWriter', function() {
 			availableWidth: 100,
 			availableHeight: 100,
 			getCurrentPage: function() { return page; },
+			getCurrentPosition: function() { return fakePosition; },
 			moveDown: function(offset) {
 				ctx.y += offset;
 				ctx.availableHeight -= offset;
@@ -48,9 +50,21 @@ describe('ElementWriter', function() {
 		it('should add lines to the current page if there\'s enough space', function() {
 			var line = buildLine(20);
 
-			ew.addLine(line);
+			var position = ew.addLine(line)
 
 			assert.equal(page.items.length, 1);
+			assert.equal(position, fakePosition);
+		});
+
+		it('should return position on page', function() {
+			var line = buildLine(20);
+
+			ew.pushContext(50,50);
+			ew.pushContext(20,30);
+			ew.pushContext(11,40);
+			var position = ew.addLine(line);
+
+			assert.equal(position, fakePosition);
 		});
 
 		it('should not add line and return false if there\'s not enough space', function() {

--- a/tests/elementWriter.js
+++ b/tests/elementWriter.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var ElementWriter = require('../src/elementWriter');
 
 describe('ElementWriter', function() {
-	var ew, ctx, page;
+	var ew, ctx, page, tracker;
 
 	beforeEach(function() {
 		page = { items: [] };
@@ -18,7 +18,8 @@ describe('ElementWriter', function() {
 				ctx.availableHeight -= offset;
 			}
 		};
-		ew = new ElementWriter(ctx);
+		tracker = {emit: function() {}};
+		ew = new ElementWriter(ctx, tracker);
 
 	});
 

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1471,7 +1471,7 @@ describe('LayoutBuilder', function() {
 
       builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 
-      assert.deepEqual(pageBreakBeforeFunction.getCall(0).args[0].startPosition, {pageNumber:1,left:40,top:40,verticalRatio:0,horizontalRatio:0});
+      assert.deepEqual(pageBreakBeforeFunction.getCall(0).args[0].startPosition, {pageNumber:1,left:40,top:40,verticalRatio:0,horizontalRatio:0, pageOrientation: 'portrait'});
     });
 
     it('should provide the pageOrientation of the node', function () {

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -46,7 +46,7 @@ describe('LayoutBuilder', function() {
 	var builder;
 
 	beforeEach(function() {
-		builder = new LayoutBuilder({ width: 400, height: 800 }, { left: 40, right: 40, top: 40, bottom: 40 });
+		builder = new LayoutBuilder({ width: 400, height: 800, orientation: 'portrait' }, { left: 40, right: 40, top: 40, bottom: 40 });
 		builder.pages = [];
 		builder.context = [ { page: -1, availableWidth: 320, availableHeight: 0 }];
 		builder.styleStack = new StyleContextStack();
@@ -1135,6 +1135,50 @@ describe('LayoutBuilder', function() {
 			);
 		});
 
+		it('should support a switch of page orientation within a document', function () {
+			var desc = [
+				{
+					text: 'Page 1, document orientation or default portrait'
+				},
+				{
+					text: 'Page 2, landscape',
+          pageBreak: 'before',
+					pageOrientation: 'landscape'
+				}];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 2);
+			assert.equal(pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pages[1].pageSize.orientation, 'landscape');
+		});
+
+		it('should support changing the page orientation to landscape consecutively', function () {
+			var desc = [
+				{
+					text: 'Page 1, document orientation or default portrait'
+				},
+				{
+					text: 'Page 2, landscape',
+          pageBreak: 'before',
+					pageOrientation: 'landscape'
+				},
+				{
+					text: 'Page 3, landscape again',
+          pageBreak: 'after',
+					pageOrientation: 'landscape'
+				}
+			];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 3);
+			assert.equal(pages[0].pageSize.orientation, 'portrait');
+			assert.equal(pages[1].pageSize.orientation, 'landscape');
+			assert.equal(pages[2].pageSize.orientation, 'landscape');
+		});
+
+
 		it('should support images');
 		it('should align image properly');
 		it('should break pages if image cannot fit on current page');
@@ -1168,7 +1212,6 @@ describe('LayoutBuilder', function() {
 			it.skip('should support current page number');
 			it.skip('should support images');
 			it.skip('should support image scaling');
-			it.skip('should support various page orientations');
 			it.skip('should support various page sizes');
 
 			// DOING
@@ -1244,7 +1287,7 @@ describe('LayoutBuilder', function() {
 		}
 
 		beforeEach(function() {
-			var pageSize = { width: 400, height: 800 };
+			var pageSize = { width: 400, height: 800, orientation: 'portrait' };
 			var pageMargins = { left: 40, top: 40, bottom: 40, right: 40};
 
 			builder2 = new LayoutBuilder(pageSize, pageMargins, {});

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1,4 +1,6 @@
 var assert = require('assert');
+var sinon = require('sinon');
+var _ = require('lodash');
 
 var Line = require('../src/line');
 var LayoutBuilder = require('../src/layoutBuilder');
@@ -45,8 +47,17 @@ var emptyTableLayout = {
 describe('LayoutBuilder', function() {
 	var builder;
 
+    var imageMeasure = {
+      measureImage: function(){
+        return {
+          width: 1,
+          height: 1
+        }
+      }
+    };
+
 	beforeEach(function() {
-		builder = new LayoutBuilder({ width: 400, height: 800, orientation: 'portrait' }, { left: 40, right: 40, top: 40, bottom: 40 });
+		builder = new LayoutBuilder({ width: 400, height: 800, orientation: 'portrait' }, { left: 40, right: 40, top: 40, bottom: 40 }, imageMeasure);
 		builder.pages = [];
 		builder.context = [ { page: -1, availableWidth: 320, availableHeight: 0 }];
 		builder.styleStack = new StyleContextStack();
@@ -1201,9 +1212,6 @@ describe('LayoutBuilder', function() {
 			it.skip('should support vector winding rules');
 			it.skip('should support colors');
 
-			it.skip('should support custom page breaks');
-			it.skip('should support custom page breaks inside nested elements');
-
 			it.skip('should support table styling');
 			it.skip('should support subtables');
 
@@ -1292,6 +1300,7 @@ describe('LayoutBuilder', function() {
 
 			builder2 = new LayoutBuilder(pageSize, pageMargins, {});
 			builder2.writer = new PageElementWriter(new DocumentContext(pageSize, pageMargins, true), builder2.tracker);
+      builder2.linearNodeList = [];
 		});
 
 		it('should return an empty array if no page breaks occur', function() {
@@ -1299,49 +1308,266 @@ describe('LayoutBuilder', function() {
 
 			var result = builder2.processRow(doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
 
-			assert(result instanceof Array);
-			assert.equal(result.length, 0);
+			assert(result.pageBreaks instanceof Array);
+			assert.equal(result.pageBreaks.length, 0);
 		});
 
 		it('on page break should return an entry with ending/starting positions', function() {
 			var doc = createTable(0, 1, 10, 5);
 			var result = builder2.processRow(doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
 
-			assert(result instanceof Array);
-			assert.equal(result.length, 1);
-			assert.equal(result[0].prevPage, 0);
-			assert.equal(result[0].prevY, 40 + 12 * 5);
+			assert(result.pageBreaks instanceof Array);
+			assert.equal(result.pageBreaks.length, 1);
+			assert.equal(result.pageBreaks[0].prevPage, 0);
+			assert.equal(result.pageBreaks[0].prevY, 40 + 12 * 5);
 		});
 
 		it('on multi-pass page break (columns or table columns) should treat bottom-most page-break as the ending position ', function() {
 			var doc = createTable(0, 1, 10, 5, 7);
 			var result = builder2.processRow(doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
 
-			assert.equal(result[0].prevY, 40 + 12 * 7);
+			assert.equal(result.pageBreaks[0].prevY, 40 + 12 * 7);
 		});
 
 		it('on multiple page breaks (more than 2 pages), should return all entries with ending/starting positions', function() {
 			var doc = createTable(0, 1, 100, 90);
 			var result = builder2.processRow(doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
 
-			assert(result instanceof Array);
-			assert.equal(result.length, 2);
-			assert.equal(result[0].prevPage, 0);
-			assert.equal(result[0].prevY, 40 + 60 * 12);
-			assert.equal(result[1].prevPage, 1);
-			assert.equal(result[1].prevY, 40 + (90 - 60) * 12);
+			assert(result.pageBreaks instanceof Array);
+			assert.equal(result.pageBreaks.length, 2);
+			assert.equal(result.pageBreaks[0].prevPage, 0);
+			assert.equal(result.pageBreaks[0].prevY, 40 + 60 * 12);
+			assert.equal(result.pageBreaks[1].prevPage, 1);
+			assert.equal(result.pageBreaks[1].prevY, 40 + (90 - 60) * 12);
 		});
 
 		it('on multiple and multi-pass page breaks should calculate bottom-most endings for every page', function() {
 			var doc = createTable(0, 1, 100, 90, 92);
 			var result = builder2.processRow(doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
 
-			assert(result instanceof Array);
-			assert.equal(result.length, 2);
-			assert.equal(result[0].prevPage, 0);
-			assert.equal(result[0].prevY, 40 + 60 * 12);
-			assert.equal(result[1].prevPage, 1);
-			assert.equal(result[1].prevY, 40 + (92 - 60) * 12);
+			assert(result.pageBreaks instanceof Array);
+			assert.equal(result.pageBreaks.length, 2);
+			assert.equal(result.pageBreaks[0].prevPage, 0);
+			assert.equal(result.pageBreaks[0].prevY, 40 + 60 * 12);
+			assert.equal(result.pageBreaks[1].prevPage, 1);
+			assert.equal(result.pageBreaks[1].prevY, 40 + (92 - 60) * 12);
 		});
 	});
+
+  describe('dynamic page break control', function () {
+
+    var docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction;
+
+
+    beforeEach(function(){
+      fontProvider = sampleTestProvider;
+      styleDictionary = {};
+    });
+
+    it('should create a pageBreak before', function(){
+
+      docStructure = [
+        {text: 'Text 1', id: 'text1'},
+        {text: 'Text 2', id: 'text2'}
+      ];
+      pageBreakBeforeFunction = function(node, otherNodesOnPage){
+        return node.id === 'text1';
+      };
+
+
+      var pages = builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.equal(pages.length, 2);
+    });
+
+    it('should not check for page break if a page break is already specified', function(){
+
+      docStructure = {
+				stack: [
+					{text: 'Text 1', id: 'text1'},
+					{text: 'Text 2', id: 'text2', pageBreak: 'before'}
+				],
+				id: 'stack'
+			};
+      pageBreakBeforeFunction = sinon.spy();
+
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert(pageBreakBeforeFunction.calledTwice);
+      assert.equal(pageBreakBeforeFunction.getCall(0).args[0].id, 'stack');
+      assert.deepEqual(_.pick(pageBreakBeforeFunction.getCall(1).args[0], ['id', 'text']), {id: 'text1', text: 'Text 1'});
+    });
+
+    it('should provide the list of following nodes on the same page', function () {
+      docStructure = [
+        {text: 'Text 1 (Page 1)', id: 'text1'},
+        {text: 'Text 2 (Page 1)', id: 'text2'},
+        {text: 'Text 3 (Page 1)', id: 'text3'},
+        {text: 'Text 4 (Page 2)', id: 'text4', pageBreak: 'before'}
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.deepEqual(_.map(pageBreakBeforeFunction.getCall(1).args[1], 'id'), ['text2','text3']);
+    });
+
+    it('should provide the list of previous nodes on the same page', function () {
+			docStructure = {
+				stack: [
+					{text: 'Text 1 (Page 1)', id: 'text1', pageBreak: 'after'},
+					{text: 'Text 2 (Page 1)', id: 'text2'},
+					{text: 'Text 3 (Page 1)', id: 'text3'},
+					{text: 'Text 4 (Page 1)', id: 'text4'}
+				],
+				id: 'stack'
+			};
+
+      pageBreakBeforeFunction = sinon.spy();
+
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.deepEqual(_.map(pageBreakBeforeFunction.getCall(4).args[2], 'id'), ['stack', 'text2','text3']);
+    });
+
+    it('should provide the pages of the node', function () {
+      docStructure = [
+        {text: 'Text 1 (Page 1)', id: 'text1'},
+        {text: 'Text 2 (Page 1)', id: 'text2'},
+        {text: 'Text 3 (Page 1)', id: 'text3'},
+        {text: 'Text 4 (Page 2)', id: 'text4', pageBreak: 'before'}
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.equal(pageBreakBeforeFunction.getCall(0).args[0].pages, 2);
+    });
+
+    it('should provide the headlineLevel of the node', function () {
+      docStructure = [
+        {text: 'Text 1 (Page 1)', id: 'text1', headlineLevel: 6}
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.equal(pageBreakBeforeFunction.getCall(1).args[0].headlineLevel, 6);
+    });
+
+    it('should provide the position of the node', function () {
+      docStructure = [
+        {text: 'Text 1 (Page 1)', id: 'text1'}
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.deepEqual(pageBreakBeforeFunction.getCall(0).args[0].startPosition, {pageNumber:1,left:40,top:40,verticalRatio:0,horizontalRatio:0});
+    });
+
+    it('should provide the pageOrientation of the node', function () {
+      docStructure = [
+        {text: 'Text 1 (Page 1)', id: 'text1', pageOrientation: 'landscape', style: 'super-text'}
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.deepEqual(pageBreakBeforeFunction.getCall(1).args[0].pageOrientation, 'landscape');
+      assert.deepEqual(pageBreakBeforeFunction.getCall(1).args[0].style, 'super-text');
+    });
+
+    it('should work with all specified elements', function () {
+
+      docStructure = [
+        {text: '', id: 'not-called-because-empty'},
+        {text: 'Text 1 (Page 1)', id: 'text'},
+        {
+          id: 'table',
+          table: {
+            body: [
+              [{
+                text: 'Column 1 (Page 1)'
+              }]
+            ]
+          }
+        },
+        {id: 'ul', ul: [{text: 'ul Item', id: 'ul-item'}]},
+        {id: 'ol', ol: [{text: 'ol Item', id: 'ol-item'}]},
+        {id: 'image', image: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD//gATQ3JlYXRlZCB3aXRoIEdJTVD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wgARCAABAAEDAREAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACP/EABQBAQAAAAAAAAAAAAAAAAAAAAX/2gAMAwEAAhADEAAAATY4f//EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAQUCf//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Bf//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Bf//EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEABj8Cf//EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAT8hf//aAAwDAQACAAMAAAAQn//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Qf//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Qf//EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAT8Qf//Z'},
+        {id: 'qr', qr: 'http://www.thoughtworks.com/join'},
+        {id: 'canvas', canvas: [ { type: 'rect', x: 0, y: 0, w: 10, h: 10 } ]},
+        {id: 'columns', columns: [{text: 'column item', id:'column-item'}]}
+
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      function validateCalled(callIndex, nodeType, id) {
+        var nodeInfo = pageBreakBeforeFunction.getCall(callIndex).args[0];
+        assert.equal(nodeInfo.id, id);
+        assert(!_.isEmpty(nodeInfo[nodeType]), 'node type accessor ' + nodeType + ' not defined');
+        assert(_.isObject(nodeInfo.startPosition), 'start position is not an object but ' + _.toString(nodeInfo.startPosition));
+        assert(_.isArray(nodeInfo.pageNumbers), 'page numbers is not an array but ' + _.toString(nodeInfo.pageNumbers));
+      }
+
+      var textIndex = 1;
+      validateCalled(textIndex, 'text', 'text');
+
+      var tableIndex = textIndex + 1;
+      validateCalled(tableIndex, 'table', 'table');
+
+      var ulIndex = tableIndex + 2;
+      validateCalled(ulIndex, 'ul', 'ul');
+      validateCalled(ulIndex + 1, 'text', 'ul-item');
+
+      var olIndex = ulIndex + 2;
+      validateCalled(olIndex, 'ol', 'ol');
+      validateCalled(olIndex + 1, 'text', 'ol-item');
+
+      var imageIndex = olIndex + 2;
+      validateCalled(imageIndex, 'image', 'image');
+
+      var qrIndex = imageIndex + 1;
+      validateCalled(qrIndex, 'qr', 'qr');
+
+      var canvasIndex = qrIndex + 1;
+      validateCalled(canvasIndex, 'canvas', 'canvas');
+
+      var columnIndex = canvasIndex + 1;
+      validateCalled(columnIndex, 'columns', 'columns');
+      validateCalled(columnIndex + 1, 'text', 'column-item');
+
+    });
+
+    it('should provide all page numbers of the node', function () {
+      var eightyLineBreaks = new Array(80).join("\n");
+      docStructure = [
+        {text: 'Text 1 (Page 1)', id: 'text1'},
+        {text: 'Text 2 (Page 1 & 2)' + eightyLineBreaks, id: 'text2'},
+        {text: 'Text 3 (Page 2)', id: 'text3'}
+      ];
+
+      pageBreakBeforeFunction = sinon.spy();
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.deepEqual(pageBreakBeforeFunction.getCall(1).args[0].pageNumbers, [1]);
+      assert.deepEqual(pageBreakBeforeFunction.getCall(2).args[0].pageNumbers, [1, 2]);
+      assert.deepEqual(pageBreakBeforeFunction.getCall(3).args[0].pageNumbers, [2]);
+    });
+
+  });
 });

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1415,6 +1415,25 @@ describe('LayoutBuilder', function() {
       assert.deepEqual(_.map(pageBreakBeforeFunction.getCall(1).args[1], 'id'), ['text2','text3']);
     });
 
+    it('should provide the list of nodes on the next page', function () {
+      docStructure = {
+        stack: [
+          {text: 'Text 1 (Page 1)', id: 'text1', pageBreak: 'after'},
+          {text: 'Text 2 (Page 1)', id: 'text2'},
+          {text: 'Text 3 (Page 1)', id: 'text3'},
+          {text: 'Text 4 (Page 1)', id: 'text4'}
+        ],
+        id: 'stack'
+      };
+
+      pageBreakBeforeFunction = sinon.spy();
+
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      assert.deepEqual(_.map(pageBreakBeforeFunction.getCall(0).args[2], 'id'), ['text2','text3', 'text4']);
+    });
+
     it('should provide the list of previous nodes on the same page', function () {
 			docStructure = {
 				stack: [
@@ -1431,7 +1450,7 @@ describe('LayoutBuilder', function() {
 
       builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 
-      assert.deepEqual(_.map(pageBreakBeforeFunction.getCall(4).args[2], 'id'), ['stack', 'text2','text3']);
+      assert.deepEqual(_.map(pageBreakBeforeFunction.getCall(4).args[3], 'id'), ['stack', 'text2','text3']);
     });
 
     it('should provide the pages of the node', function () {

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -77,7 +77,7 @@ describe('PageElementWriter', function() {
 			var position = addOneTenthLines(10);
 
 			assert.equal(ctx.pages.length, 1);
-			assert.deepEqual(position, {pageNumber:1,left:MARGINS.left, top: (9/10 * AVAILABLE_HEIGHT) + MARGINS.top, verticalRatio: 0.9, horizontalRatio: 0});
+			assert.deepEqual(position, {pageNumber:1,left:MARGINS.left, top: (9/10 * AVAILABLE_HEIGHT) + MARGINS.top, verticalRatio: 0.9, horizontalRatio: 0, pageOrientation: 'portrait'});
 		});
 
 		it('should add new pages if there\'s not enough space left', function() {
@@ -86,7 +86,7 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages.length, 2);
 			assert.equal(ctx.pages[0].items.length, 10);
 			assert.equal(ctx.pages[1].items.length, 1);
-      assert.deepEqual(position, {pageNumber:2,left: MARGINS.left, top: MARGINS.top, verticalRatio: 0, horizontalRatio: 0});
+      assert.deepEqual(position, {pageNumber:2,left: MARGINS.left, top: MARGINS.top, verticalRatio: 0, horizontalRatio: 0, pageOrientation: 'portrait'});
 		});
 
 		it('should subtract line height from availableHeight when adding a line and update current y position', function() {

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -44,10 +44,12 @@ describe('PageElementWriter', function() {
 	}
 
 	function addOneTenthLines(count) {
+    var lastPosition;
 		for(var i = 0; i < count; i++) {
 			var line = buildLine(AVAILABLE_HEIGHT/10);
-			pew.addLine(line);
+			lastPosition = pew.addLine(line);
 		}
+    return lastPosition;
 	}
 
 	function createRepeatable(marker, height) {
@@ -72,17 +74,19 @@ describe('PageElementWriter', function() {
 
 	describe('addLine', function() {
 		it('should add new lines if there\'s enough space left', function() {
-			addOneTenthLines(10);
+			var position = addOneTenthLines(10);
 
 			assert.equal(ctx.pages.length, 1);
+			assert.deepEqual(position, {pageNumber:1,left:MARGINS.left, top: (9/10 * AVAILABLE_HEIGHT) + MARGINS.top, verticalRatio: 0.9, horizontalRatio: 0});
 		});
 
 		it('should add new pages if there\'s not enough space left', function() {
-			addOneTenthLines(11);
+			var position = addOneTenthLines(11);
 
 			assert.equal(ctx.pages.length, 2);
 			assert.equal(ctx.pages[0].items.length, 10);
 			assert.equal(ctx.pages[1].items.length, 1);
+      assert.deepEqual(position, {pageNumber:2,left: MARGINS.left, top: MARGINS.top, verticalRatio: 0, horizontalRatio: 0});
 		});
 
 		it('should subtract line height from availableHeight when adding a line and update current y position', function() {

--- a/tests/pageElementWriter.js
+++ b/tests/pageElementWriter.js
@@ -1,11 +1,26 @@
 var assert = require('assert');
+var sinon = require('sinon');
 
 var DocumentContext = require('../src/documentContext');
 var PageElementWriter = require('../src/pageElementWriter');
 
 describe('PageElementWriter', function() {
-	var pew;
-	var ctx;
+	var pew, ctx, tracker, pageSize;
+
+	var DOCUMENT_WIDTH = 600;
+	var DOCUMENT_HEIGHT = 1100;
+	var DOCUMENT_ORIENTATION = 'portrait';
+
+
+	var MARGINS = {
+		left: 40,
+		right: 60,
+		top: 30,
+		bottom: 70
+	};
+
+	AVAILABLE_HEIGHT = 1000;
+	AVAILABLE_WIDTH = 500;
 
 	function buildLine(height, alignment, x, y) {
 		return {
@@ -30,7 +45,7 @@ describe('PageElementWriter', function() {
 
 	function addOneTenthLines(count) {
 		for(var i = 0; i < count; i++) {
-			var line = buildLine((800-60-60)/10);
+			var line = buildLine(AVAILABLE_HEIGHT/10);
 			pew.addLine(line);
 		}
 	}
@@ -48,10 +63,11 @@ describe('PageElementWriter', function() {
         });
 		return rep;
 	}
-
 	beforeEach(function() {
-		ctx = new DocumentContext({ width: 400, height: 800 }, { left: 40, right: 40, top: 60, bottom: 60 });
-		pew = new PageElementWriter(ctx);
+		pageSize = {width: DOCUMENT_WIDTH, height: DOCUMENT_HEIGHT, orientation: DOCUMENT_ORIENTATION};
+    ctx = new DocumentContext(pageSize, MARGINS);
+		tracker = { emit: sinon.spy() };
+		pew = new PageElementWriter(ctx, tracker);
 	});
 
 	describe('addLine', function() {
@@ -72,8 +88,8 @@ describe('PageElementWriter', function() {
 		it('should subtract line height from availableHeight when adding a line and update current y position', function() {
 			pew.addLine(buildLine(40));
 
-			assert.equal(ctx.y, 60 + 40);
-			assert.equal(ctx.availableHeight, 800 - 60 - 60 - 40);
+			assert.equal(ctx.y, MARGINS.top + 40);
+			assert.equal(ctx.availableHeight, AVAILABLE_HEIGHT - 40);
 		});
 
 		it('should add repeatable fragments if they exist and a new page is created before adding the line', function() {
@@ -167,10 +183,10 @@ describe('PageElementWriter', function() {
 
 			pew.commitUnbreakableBlock();
 
-			assert.equal(ctx.pages[1].items[0].item.x, 40);
-			assert.equal(ctx.pages[1].items[0].item.y, 60);
-			assert.equal(ctx.pages[1].items[1].item.x, 40);
-			assert.equal(ctx.pages[1].items[1].item.y, 60 + ctx.pages[1].items[0].item.getHeight());
+			assert.equal(ctx.pages[1].items[0].item.x, MARGINS.left);
+			assert.equal(ctx.pages[1].items[0].item.y, MARGINS.top);
+			assert.equal(ctx.pages[1].items[1].item.x, MARGINS.left);
+			assert.equal(ctx.pages[1].items[1].item.y, MARGINS.top + AVAILABLE_HEIGHT/10);
 		});
 
 		it('should add lines below any repeatable fragments if they exist and a new page is created', function() {
@@ -188,8 +204,8 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages.length, 2);
 			assert.equal(ctx.pages[1].items[0].item.marker, 'rep');
 			assert.equal(ctx.pages[1].items[1].item.marker, 'another');
-			assert.equal(ctx.pages[1].items[1].item.x, 40);
-			assert.equal(ctx.pages[1].items[1].item.y, 60 + 50);
+			assert.equal(ctx.pages[1].items[1].item.x, MARGINS.left);
+			assert.equal(ctx.pages[1].items[1].item.y, MARGINS.top + 50);
 		});
 
 		it('should make all further calls to addLine add lines again to the page when transaction finishes', function() {
@@ -242,9 +258,31 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages[1].items[0].item.marker, 'rep');
 			assert.equal(ctx.pages[1].items[1].item.marker, 'rep');
 			assert.equal(ctx.pages[1].items[2].item.marker, 'rep');
-			assert.equal(ctx.pages[1].items[2].item.y, 60 + 2 * 68);
+			assert.equal(ctx.pages[1].items[2].item.y, MARGINS.top + 2 * AVAILABLE_HEIGHT/10);
 			assert(!ctx.pages[1].items[3].item.marker);
-			assert.equal(ctx.pages[1].items[3].item.y, ctx.pages[1].items[2].item.y + 68);
+			assert.equal(ctx.pages[1].items[3].item.y, ctx.pages[1].items[2].item.y + AVAILABLE_HEIGHT/10);
+		});
+
+		it('should reserve space for repeatable fragment to the top when reusing page', function() {
+			addOneTenthLines(6);
+
+			pew.beginUnbreakableBlock();
+			var uCtx = pew.writer.context;
+
+			addOneTenthLines(3);
+			uCtx.pages[0].items.forEach(function(item) { item.item.marker = 'rep'; });
+			var rep = pew.currentBlockToRepeatable();
+			pew.pushToRepeatables(rep);
+			pew.commitUnbreakableBlock();
+
+
+      ctx.pages.push({items: [], pageSize: pageSize});
+
+			addOneTenthLines(2);
+
+			assert.equal(ctx.pages.length, 2);
+
+			assert.equal(ctx.pages[1].items[0].item.y, MARGINS.top + 3 * AVAILABLE_HEIGHT/10);
 		});
 
 		it('should add repeatable fragments in the same order they have been added to the repeatable fragments collection', function() {
@@ -256,11 +294,79 @@ describe('PageElementWriter', function() {
 			assert.equal(ctx.pages.length, 2);
 			assert.equal(ctx.pages[1].items.length, 3);
 			assert.equal(ctx.pages[1].items[0].item.marker, 'rep1');
-			assert.equal(ctx.pages[1].items[0].item.y, 60);
+			assert.equal(ctx.pages[1].items[0].item.y, MARGINS.top);
 			assert.equal(ctx.pages[1].items[1].item.marker, 'rep2');
-			assert.equal(ctx.pages[1].items[1].item.y, 60 + 50);
+			assert.equal(ctx.pages[1].items[1].item.y, MARGINS.top + 50);
 			assert(!ctx.pages[1].items[2].item.marker);
-			assert.equal(ctx.pages[1].items[2].item.y, 60 + 50 + 60);
+			assert.equal(ctx.pages[1].items[2].item.y, MARGINS.top + 50 + 60);
+		});
+
+		it('should switch width and height if page changes from portrait to landscape', function() {
+			addOneTenthLines(6);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, DOCUMENT_ORIENTATION);
+
+			pew.moveToNextPage('landscape');
+
+			assert.equal(ctx.pages.length, 2);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, 'landscape');
+		});
+
+		it('should switch width and height if page changes from landscape to portrait', function() {
+			ctx.getCurrentPage().pageSize.orientation = 'landscape';
+			ctx.getCurrentPage().pageSize.width = DOCUMENT_WIDTH;
+			ctx.getCurrentPage().pageSize.height = DOCUMENT_HEIGHT;
+			
+			addOneTenthLines(6);
+			pew.moveToNextPage('portrait');
+
+			assert.equal(ctx.pages.length, 2);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, 'portrait');
+		});
+
+		it('should not switch width and height if page changes from landscape to landscape', function() {
+			ctx.pageOrientation = undefined;
+			addOneTenthLines(6);
+			pew.moveToNextPage('landscape');
+			pew.moveToNextPage('landscape');
+
+			assert.equal(ctx.pages.length, 3);
+			assert.equal(ctx.getCurrentPage().pageSize.width, DOCUMENT_HEIGHT);
+			assert.equal(ctx.getCurrentPage().pageSize.height, DOCUMENT_WIDTH);
+			assert.equal(ctx.getCurrentPage().pageSize.orientation, 'landscape');
+		});
+
+		it('should create new page', function () {
+			addOneTenthLines(1);
+			pew.moveToNextPage();
+
+			assert.equal(ctx.pages.length, 2);
+			assert.equal(ctx.y, MARGINS.top);
+			assert.equal(ctx.availableHeight, AVAILABLE_HEIGHT);
+			assert.equal(ctx.availableWidth, AVAILABLE_WIDTH);
+			assert.equal(tracker.emit.callCount, 2); // move to first page to write a line, and then move to next page
+			assert.deepEqual(tracker.emit.getCall(1).args, ['pageChanged', {prevPage: 0, prevY: MARGINS.top + AVAILABLE_HEIGHT / 10, y: MARGINS.top}]);
+		});
+
+		it('should use existing page', function () {
+			addOneTenthLines(1);
+			ctx.pages.push({items: [], pageSize: pageSize});
+			ctx.availableWidth = 'garbage';
+			ctx.availableHeight = 'garbage';
+
+			pew.moveToNextPage();
+
+			assert.equal(ctx.page, 1);
+			assert.equal(ctx.y, MARGINS.top);
+			assert.equal(ctx.availableHeight, AVAILABLE_HEIGHT);
+			assert.equal(ctx.availableWidth, AVAILABLE_WIDTH);
+			assert.equal(tracker.emit.callCount, 2);
+			assert.deepEqual(tracker.emit.getCall(1).args, ['pageChanged', {prevPage: 0, prevY: MARGINS.top + AVAILABLE_HEIGHT / 10, y: MARGINS.top}]);
 		});
 	});
 });

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -1,0 +1,135 @@
+/*global _ */
+/*jshint globalstrict:true*/
+'use strict';
+
+var assert = require('assert');
+var Printer = require('../src/printer.js');
+var sinon = require('sinon');
+var Pdfkit = require('pdfkit');
+
+describe('Printer', function () {
+
+  var SHORT_SIDE = 1000, LONG_SIDE = 2000;
+  var fontDescriptors, printer;
+
+  beforeEach(function() {
+    fontDescriptors = {
+      Roboto: {
+        normal: 'examples/fonts/Roboto-Regular.ttf'
+      }
+    };
+    Pdfkit.prototype.addPage = sinon.spy(Pdfkit.prototype.addPage);
+
+  });
+
+  it('should pass switched width and height to pdfkit if page orientation changes from default portrait to landscape', function () {
+    printer = new Printer(fontDescriptors);
+    var docDefinition = {
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageBreak: 'before',
+          pageOrientation: 'landscape'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    assert(Pdfkit.prototype.addPage.callCount === 2);
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
+  });
+
+  it('should pass switched width and height to pdfkit if page orientation changes from portrait to landscape', function () {
+    printer = new Printer(fontDescriptors);
+    var docDefinition = {
+      pageOrientation: 'portrait',
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageBreak: 'before',
+          pageOrientation: 'landscape'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    assert(Pdfkit.prototype.addPage.callCount === 2);
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
+  });
+
+  it('should pass switched width and height to pdfkit if page orientation changes from landscape to portrait', function () {
+    printer = new Printer(fontDescriptors);
+
+    var docDefinition = {
+      pageOrientation: 'landscape',
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageBreak: 'before',
+          pageOrientation: 'portrait'
+        },
+        {
+          text: 'Page 3 still portrait',
+          pageBreak: 'before'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    assert(Pdfkit.prototype.addPage.callCount === 3);
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [SHORT_SIDE, LONG_SIDE]);
+    assert.deepEqual(Pdfkit.prototype.addPage.thirdCall.args[0].size, [SHORT_SIDE, LONG_SIDE]);
+  });
+
+
+  it('should not switch width and height for pdfkit if page orientation changes from landscape to landscape', function () {
+    printer = new Printer(fontDescriptors);
+    var docDefinition = {
+      pageOrientation: 'portrait',
+      pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+      content: [
+        {
+          text: 'Page 1'
+        },
+        {
+          text: 'Page 2',
+          pageBreak: 'before',
+          pageOrientation: 'landscape'
+        },
+        {
+          text: 'Page 3 landscape again',
+          pageOrientation: 'landscape',
+          pageBreak: 'after'
+        }
+      ]
+    };
+    printer.createPdfKitDocument(docDefinition);
+
+    console.log('mysterious fourth call arguments', Pdfkit.prototype.addPage.lastCall.args);
+    assert.equal(Pdfkit.prototype.addPage.callCount, 3);
+
+
+    assert(Pdfkit.prototype.addPage.firstCall.calledWith(undefined));
+    assert.deepEqual(Pdfkit.prototype.addPage.secondCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
+    assert.deepEqual(Pdfkit.prototype.addPage.thirdCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
+  });
+
+});

--- a/tests/tableProcessor.js
+++ b/tests/tableProcessor.js
@@ -1,2 +1,126 @@
 /* jslint node: true */
 'use strict';
+var assert = require('assert');
+
+var TableProcessor = require('../src/tableProcessor');
+
+describe('TableProcessor', function () {
+
+  function noop(){}
+
+  var defaultLayout, contextFake, writerFake;
+
+
+  beforeEach(function(){
+    defaultLayout = {
+      hLineWidth: function (i, node) {
+        return 1;
+      }, //return node.table.headerRows && i === node.table.headerRows && 3 || 0; },
+      vLineWidth: function (i, node) {
+        return 1;
+      },
+      hLineColor: function (i, node) {
+        return 'black';
+      },
+      vLineColor: function (i, node) {
+        return 'black';
+      },
+      paddingLeft: function (i, node) {
+        return 4;
+      }, //i && 4 || 0; },
+      paddingRight: function (i, node) {
+        return 4;
+      }, //(i < node.table.widths.length - 1) ? 4 : 0; },
+      paddingTop: function (i, node) {
+        return 2;
+      },
+      paddingBottom: function (i, node) {
+        return 2;
+      }
+    };
+
+    contextFake = {
+      moveDown: noop
+    };
+
+    writerFake = {
+      context: function () {
+        return contextFake;
+      },
+      addVector : function(vector, ignoreContextX, ignoreContextY, index){
+        assert.equal(vector.lineColor, 'nice shiny color');
+        addVectorCallCount ++;
+      },
+      tracker: {
+        startTracking: noop,
+        stopTracking: noop
+      }
+    };
+
+  })
+
+
+  it('should use the line colors function (regression #161)', function () {
+
+    var addVectorCallCount = 0;
+
+    writerFake.addVector = function(vector){
+      assert.equal(vector.lineColor, 'nice shiny color');
+      addVectorCallCount ++;
+    };
+
+
+    var tableNode = {
+      table: {
+        body: [
+          ['A1', 'A2'],
+          ['B1', 'B2']
+        ]
+      }
+    };
+
+    var processor = new TableProcessor(tableNode);
+    defaultLayout.vLineColor = function() {return 'nice shiny color'};
+    defaultLayout.hLineColor = function() {return 'nice shiny color'};
+    processor.layout = defaultLayout;
+    processor.rowSpanData = [{ left: 0, rowSpan: 0 }, { left: 0, rowSpan: 0 }]
+
+    processor.beginRow(0, writerFake);
+    processor.endRow(0, writerFake, []);
+
+    assert.equal(addVectorCallCount, 4)
+  });
+
+  it('should use the line colors constants (regression #161)', function () {
+
+    var addVectorCallCount = 0;
+
+    writerFake.addVector = function(vector){
+      assert.equal(vector.lineColor, 'nice shiny color');
+      addVectorCallCount ++;
+    };
+
+
+    var tableNode = {
+      table: {
+        body: [
+          ['A1', 'A2'],
+          ['B1', 'B2']
+        ]
+      }
+    };
+
+    var processor = new TableProcessor(tableNode);
+    defaultLayout.vLineColor = 'nice shiny color';
+    defaultLayout.hLineColor = 'nice shiny color';
+    processor.layout = defaultLayout;
+    processor.rowSpanData = [{ left: 0, rowSpan: 0 }, { left: 0, rowSpan: 0 }]
+
+    processor.beginRow(0, writerFake);
+    processor.endRow(0, writerFake, []);
+
+    assert.equal(addVectorCallCount, 4)
+  });
+
+
+});


### PR DESCRIPTION
This pull request groups several features and bug-fixes. We open it as one pull request, because we want to avoid merge conflicts during development.

Features:
* Introduce new styling properties marginLeft, marginRight, marginTop, and marginBottom.
* Add the capability to have switch of page orientation per page.
* Adds an editorconfig.
* Adding possibility to specify line height.
* Access to internal pages array, to have better testing capabilities.
* Dynamically control page breaks, for instance to avoid orphan childs.

Bug Fixes:
* Add the type to the font name for pdfkit. This is to avoid using the same type (normal, bold, italics, bolditalics) every time a font is requested. Fixes #162.
* Use function for vLineColor if provided on table layout. Fixes #166.

## Introduce new styling properties marginLeft, marginRight, marginTop, and marginBottom.
An element in the document definition can now specify margin on any side individually. This allows to combine margins from different styles.

````javascript
 {
  content: [
    {text: 'text with style 1', style: ['style1']},
    {text: 'text with style 2', style: ['style2']},
    {text: 'text with both styles', style: ['style1', 'style2']}
  ], 
  styles: {
   style1: {
       marginTop: 30
   }, 
   style2: {
       marginLeft: 20
    }
  }
}
````

## Add the capability to have switch of page orientation per page.
This allows a document to switch between landscape and portrait in a document.

````javascript
    {
      pageOrientation: 'portrait',
      content: [
        {text: 'Text on Portrait'},
        {text: 'Text on Landscape', pageOrientation: 'landscape', pageBreak: 'before'},
        {text: 'Text on Landscape 2', pageOrientation: 'portrait', pageBreak: 'after'},
        {text: 'Text on Portrait 2'},
      ]
    }
````

**Important** you need to specify a page break on the same node, to make sure the page can switch it's orientation.

## Adds an editorconfig.
An ``.editorconfig`` file makes sure that coding conventions, especially whitespaces, are kept within each editor.

## Adding possibility to specify line height.
A new style property ``lineHeight`` is now available.
````javascript
    {
      content: [{text: 'this is a very long text', lineHeight: 1.5}]
    }
````

``lineHeight`` is a relative value.

## Access to internal pages array, to have better testing capabilities.
This allows writing integration test agains a array of pages in PDF Make.

````javascript
pdfMake.createPdf(docDefinition)._getPages({}, function(pages){
  assert.equal(pages.length, 2);
});
````

## Dynamically control page breaks, for instance to avoid orphan childs.
You can now specify a ``pageBreakBefore`` function, which can determine if a page break should be inserted before the page break. To implement a 'no orphan child' rule, this could like like this:

````javascript
var dd = {
    content: [
       {text: '1 Headline', headlineLevel: 1},
       'Some long text of variable length ...',
       {text: '2 Headline', headlineLevel: 1},
       'Some long text of variable length ...',
       {text: '3 Headline', headlineLevel: 1},
       'Some long text of variable length ...',
    ],
  pageBreakBefore: function(currentNode, followingNodesOnPage, nodesOnNextPage, previousNodesOnPage) {
     return currentNode.headlineLevel === 1 && followingNodesOnPage.length === 0;
  }
}
````

If ``pageBreakBefore`` returns true, a page break will be added before the ``currentNode``. Current node has the following information attached:

````javascript
{
   id: '<as specified in doc definition>', 
   headlineLevel: '<as specified in doc definition>',
   text: '<as specified in doc definition>', 
   ul: '<as specified in doc definition>', 
   ol: '<as specified in doc definition>', 
   table: '<as specified in doc definition>', 
   image: '<as specified in doc definition>', 
   qr: '<as specified in doc definition>', 
   canvas: '<as specified in doc definition>', 
   columns: '<as specified in doc definition>', 
   style: '<as specified in doc definition>', 
   pageOrientation '<as specified in doc definition>',
   pageNumbers: [2, 3], // The pages this element is visible on (e.g. multi-line text could be on more than one page)
   pages: 6, // the total number of pages of this document
   stack: false, // if this is an element which encapsulates multiple sub-objects
   startPosition: {
     pageNumber: 2, // the page this node starts on
     pageOrientation: 'landscape', // the orientation of this page
     left: 60, // the left position
     right: 60, // the right position
     verticalRatio: 0.2, // the ratio of space used vertically in this document (excluding margins)
     horizontalRatio: 0.0  // the ratio of space used horizontally in this document (excluding margins)
   }
}
````
