### PR TITLE
adding the vfs_fonts.js to "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Bartek Pampuch <bartosz.pampuch@gmail.com>"
   ],
   "description": "Client/server side PDF printing in pure JavaScript",
-  "main": "build/pdfmake.js",
+  "main": ["build/pdfmake.js", "build/vfs_fonts.js"],
   "moduleType": [
     "globals"
   ],


### PR DESCRIPTION
adding the vfs_fonts.js to main enables grunt to add it to index.html when running 'grunt wiredep'