### PR TITLE
Embed fonts multiple times to allow more than 92 characters.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,7 +128,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-dump-dir');
 	grunt.loadNpmTasks('grunt-contrib-concat');
 
-	grunt.registerTask('test', [ 'replace:exposeTestMethods', 'jshint', 'mochacov', 'replace:hideTestMethods' ]);
+	grunt.registerTask('test', [ 'replace:fixPdfKit', 'replace:exposeTestMethods', 'jshint', 'mochacov', 'replace:hideTestMethods' ]);
 
 	grunt.registerTask('fixVfsFonts', 'Adds semicolon to the end of vfs_fonts.js', function () {
 	      var file = grunt.file.read('build/vfs_fonts.js');

--- a/src/fontProvider.js
+++ b/src/fontProvider.js
@@ -1,0 +1,61 @@
+/* jslint node: true */
+'use strict';
+
+var _ = require('lodash');
+var FontWrapper = require('./fontWrapper');
+
+function typeName(bold, italics){
+	var type = 'normal';
+	if (bold && italics) type = 'bolditalics';
+	else if (bold) type = 'bold';
+	else if (italics) type = 'italics';
+	return type;
+}
+
+function FontProvider(fontDescriptors, pdfDoc) {
+	this.fonts = {};
+	this.pdfDoc = pdfDoc;
+	this.fontWrappers = {};
+
+	for(var font in fontDescriptors) {
+		if (fontDescriptors.hasOwnProperty(font)) {
+			var fontDef = fontDescriptors[font];
+
+			this.fonts[font] = {
+				normal: fontDef.normal,
+				bold: fontDef.bold,
+				italics: fontDef.italics,
+				bolditalics: fontDef.bolditalics
+			};
+		}
+	}
+}
+
+FontProvider.prototype.provideFont = function(familyName, bold, italics) {
+  if (!this.fonts[familyName]) return this.pdfDoc._font;
+	var type = typeName(bold, italics);
+
+  this.fontWrappers[familyName] = this.fontWrappers[familyName] || {};
+
+  if (!this.fontWrappers[familyName][type]) {
+		this.fontWrappers[familyName][type] = new FontWrapper(this.pdfDoc, this.fonts[familyName][type], familyName + '(' + type + ')');
+	}
+
+  return this.fontWrappers[familyName][type];
+};
+
+FontProvider.prototype.setFontRefsToPdfDoc = function(){
+  var self = this;
+
+  _.each(self.fontWrappers, function(fontFamily) {
+    _.each(fontFamily, function(fontWrapper){
+      _.each(fontWrapper.pdfFonts, function(font){
+        if (!self.pdfDoc.page.fonts[font.id]) {
+          self.pdfDoc.page.fonts[font.id] = font.ref();
+        }
+      });
+    });
+  });
+};
+
+module.exports = FontProvider;

--- a/src/fontWrapper.js
+++ b/src/fontWrapper.js
@@ -1,0 +1,102 @@
+/* jslint node: true */
+'use strict';
+
+var _ = require('lodash');
+
+function FontWrapper(pdfkitDoc, path, fontName){
+	this.MAX_CHAR_TYPES = 92;
+
+	this.pdfkitDoc = pdfkitDoc;
+	this.path = path;
+	this.pdfFonts = [];
+	this.charCatalogue = [];
+	this.name = fontName;
+
+  this.__defineGetter__('ascender', function(){
+    var font = this.getFont(0);
+    return font.ascender;
+  });
+
+}
+// private
+
+FontWrapper.prototype.getFont = function(index){
+	if(!this.pdfFonts[index]){
+
+		var pseudoName = this.name + index;
+
+		if(this.postscriptName){
+			delete this.pdfkitDoc._fontFamilies[this.postscriptName];
+		}
+
+		this.pdfFonts[index] = this.pdfkitDoc.font(this.path, pseudoName)._font;
+		if(!this.postscriptName){
+			this.postscriptName = this.pdfFonts[index].name;
+		}
+	}
+
+	return this.pdfFonts[index];
+};
+
+// public
+FontWrapper.prototype.widthOfString = function(){
+	var font = this.getFont(0);
+	return font.widthOfString.apply(font, arguments);
+};
+
+FontWrapper.prototype.lineHeight = function(){
+	var font = this.getFont(0);
+	return font.lineHeight.apply(font, arguments);
+};
+
+FontWrapper.prototype.ref = function(){
+	var font = this.getFont(0);
+	return font.ref.apply(font, arguments);
+};
+
+var toCharCode = function(char){
+  return char.charCodeAt(0);
+};
+
+FontWrapper.prototype.encode = function(text){
+  var self = this;
+
+  var charTypesInInline = _.chain(text.split('')).map(toCharCode).uniq().value();
+	if (charTypesInInline.length > self.MAX_CHAR_TYPES) {
+		throw new Error('Inline has more than '+ self.MAX_CHAR_TYPES + ': ' + text + ' different character types and therefore cannot be properly embedded into pdf.');
+	}
+
+
+  var characterFitInFontWithIndex = function (charCatalogue) {
+
+    return _.uniq(charCatalogue.concat(charTypesInInline)).length <= self.MAX_CHAR_TYPES;
+  };
+
+  var index = _.findIndex(self.charCatalogue, characterFitInFontWithIndex);
+
+  if(index < 0){
+    index = self.charCatalogue.length;
+    self.charCatalogue[index] = [];
+  }
+
+	var font = this.getFont(index);
+	font.use(text);
+
+  _.each(charTypesInInline, function(charCode){
+    if(!_.includes(self.charCatalogue[index], charCode)){
+      self.charCatalogue[index].push(charCode);
+    }
+  });
+
+  var encodedText = _.map(font.encode(text), function (char) {
+    return char.charCodeAt(0).toString(16);
+  }).join('');
+
+  return {
+    encodedText: encodedText,
+    fontId: font.id
+  };
+};
+
+
+module.exports = FontWrapper;

--- a/src/fontWrapper.js
+++ b/src/fontWrapper.js
@@ -16,6 +16,10 @@ function FontWrapper(pdfkitDoc, path, fontName){
     var font = this.getFont(0);
     return font.ascender;
   });
+  this.__defineGetter__('decender', function(){
+    var font = this.getFont(0);
+    return font.decender;
+  });
 
 }
 // private

--- a/tests/fontWrapper.js
+++ b/tests/fontWrapper.js
@@ -1,0 +1,117 @@
+var assert = require('assert');
+var _ = require('lodash');
+
+var FontWrapper = require('../src/fontWrapper');
+var PdfKit = require('pdfkit');
+
+describe('FontWrapper', function() {
+	var fontWrapper, pdfDoc;
+
+
+  function getEncodedUnicodes(index, pdfDoc){
+    return pdfDoc.font('Roboto (bolditalic)' + index)._font.subset.unicodes;
+  }
+
+	beforeEach(function() {
+		pdfDoc = new PdfKit({ size: [ 595.28, 841.89 ], compress: false});
+		fontWrapper = new FontWrapper(pdfDoc, 'examples/fonts/Roboto-Italic.ttf', 'Roboto (bolditalic)')
+	});
+
+	describe('encoding', function() {
+
+
+
+
+		it('encodes text', function () {
+			var encoded = fontWrapper.encode('Anna ');
+
+      // A  n  n  a
+      // 21 22 22 23 24
+			assert.equal(encoded.encodedText, '2122222324');
+			assert.equal(encoded.fontId, 'F1');
+			assert.equal(pdfDoc._fontCount, 1);
+      var encodedUnicodes = getEncodedUnicodes(0, pdfDoc);
+      assert.equal(encodedUnicodes['A'.charCodeAt(0)], 33);
+			assert.equal(encodedUnicodes['n'.charCodeAt(0)], 34);
+			assert.equal(encodedUnicodes['a'.charCodeAt(0)], 35);
+			assert.equal(encodedUnicodes[' '.charCodeAt(0)], 36);
+		});
+
+    it('encodes text and re-use characters', function () {
+      fontWrapper.encode('Anna ');
+      var encoded = fontWrapper.encode('na na AAA!');
+
+      // A  n  n  a
+      // 21 22 22 23 24
+
+      // n  a     n  a     A  A  A  !
+      // 22 23 24 22 23 24 21 21 21 25
+      assert.equal(encoded.encodedText, '22232422232421212125');
+      assert.equal(encoded.fontId, 'F1');
+      assert.equal(pdfDoc._fontCount, 1);
+      var encodedUnicodes = getEncodedUnicodes(0, pdfDoc);
+      assert.equal(encodedUnicodes['A'.charCodeAt(0)], 33);
+      assert.equal(encodedUnicodes['n'.charCodeAt(0)], 34);
+      assert.equal(encodedUnicodes['a'.charCodeAt(0)], 35);
+      assert.equal(encodedUnicodes[' '.charCodeAt(0)], 36);
+      assert.equal(encodedUnicodes['!'.charCodeAt(0)], 37);
+    });
+
+    it('encodes in new font when old font is used', function () {
+      var text = _.times(91, String.fromCharCode).join(''); // does not include a-z, includes 0-9 & A-Z
+      fontWrapper.encode(text);
+      var encoded = fontWrapper.encode('cannot');
+
+      // c  a  n  n  o  t
+      // 21 22 23 23 24 25
+      assert.equal(encoded.encodedText, '212223232425');
+      assert.equal(encoded.fontId, 'F2');
+      assert.equal(pdfDoc._fontCount, 2);
+      var encodedUnicodes = getEncodedUnicodes(1, pdfDoc);
+      assert.equal(encodedUnicodes['c'.charCodeAt(0)], 33);
+      assert.equal(encodedUnicodes['a'.charCodeAt(0)], 34);
+      assert.equal(encodedUnicodes['n'.charCodeAt(0)], 35);
+      assert.equal(encodedUnicodes['o'.charCodeAt(0)], 36);
+      assert.equal(encodedUnicodes['t'.charCodeAt(0)], 37);
+    });
+
+    it('encodes NOT in new font when both unique character sets are equal', function () {
+      var text1 = _.times(47, String.fromCharCode).join(''); // does not include a-z, includes 0-9 & A-Z
+      fontWrapper.encode(text1);
+
+      var text2 = _.times(47, String.fromCharCode).join(''); // does not include a-z, includes 0-9 & A-Z
+      fontWrapper.encode(text2);
+
+      assert.equal(pdfDoc._fontCount, 1);
+      assert.equal(pdfDoc._font.id, 'F1');
+      assert.equal(pdfDoc._font.name, 'Roboto-Italic');
+    });
+
+    it('use other font when it still has enough space', function () {
+      var text1 = 'cannot',
+          text2 = _.times(92, String.fromCharCode).join(''), // does not include a-z, includes 0-9 & A-Z
+          text3 = 'This can work.';
+
+
+      fontWrapper.encode(text1);
+      fontWrapper.encode(text2);
+      var encoded = fontWrapper.encode(text3);
+
+      // c  a  n  n  o  t
+      // 21 22 23 23 24 25
+
+      // T  h  i  s     c  a  n     w  o  r  k  .
+      // 26 27 28 29 2a 21 22 23 2a 2b 24 2c 2d 2e
+      assert.equal(encoded.encodedText, '262728292a2122232a2b242c2d2e');
+      assert.equal(encoded.fontId, 'F1');
+      assert.equal(pdfDoc._fontCount, 2);
+      var encodedUnicodes = getEncodedUnicodes(0, pdfDoc);
+      assert.equal(encodedUnicodes['T'.charCodeAt(0)], 38);
+      assert.equal(encodedUnicodes['h'.charCodeAt(0)], 39);
+      assert.equal(encodedUnicodes['i'.charCodeAt(0)], 40);
+      assert.equal(encodedUnicodes['s'.charCodeAt(0)], 41);
+      assert.equal(encodedUnicodes[' '.charCodeAt(0)], 42);
+    });
+
+	});
+});

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -131,4 +131,50 @@ describe('Printer', function () {
     assert.deepEqual(Pdfkit.prototype.addPage.thirdCall.args[0].size, [LONG_SIDE, SHORT_SIDE]);
   });
 
+	it('should print bullet vectors as ellipses', function () {
+		printer = new Printer(fontDescriptors);
+		var docDefinition = {
+			pageOrientation: 'portrait',
+			pageSize: { width: SHORT_SIDE, height: LONG_SIDE },
+			content: [
+				{
+					"stack": [
+						{
+							"ul": [
+								{ "text": "item1" },
+								{ "text": "item2" }
+							]
+						}
+					]
+				}
+			]
+		};
+		Pdfkit.prototype.ellipse = sinon.spy(Pdfkit.prototype.ellipse);
+
+		printer.createPdfKitDocument(docDefinition);
+
+		function assertEllipse(ellipseCallArgs) {
+			var firstEllipse = {
+				x: ellipseCallArgs[0],
+				y: ellipseCallArgs[1],
+				r1: ellipseCallArgs[2],
+				r2: ellipseCallArgs[3]
+			};
+			assert(firstEllipse.x !== undefined);
+			assert(! isNaN(firstEllipse.x));
+			assert(firstEllipse.y !== undefined);
+			assert(! isNaN(firstEllipse.y));
+			assert(firstEllipse.r1 !== undefined);
+			assert(! isNaN(firstEllipse.r1));
+			assert(firstEllipse.r2 !== undefined);
+			assert(! isNaN(firstEllipse.r2));
+		}
+
+		assert.equal(Pdfkit.prototype.ellipse.callCount, 2);
+
+		assertEllipse(Pdfkit.prototype.ellipse.firstCall.args);
+		assertEllipse(Pdfkit.prototype.ellipse.secondCall.args);
+
+	});
+
 });


### PR DESCRIPTION
This pull request is supposed to fix issues with more than 92 characters in the same font (see #165). The solution is to embed the font multiple times into a pdf - each with a different cmap to transform unicodes to actual font glyphs.

I make it a pull request, so people can discuss the solution.

Credits go also to @SteffiPeTaffy, @birgitta410 and @hgsy.

@bpampuch What do you think?