### PR TITLE
[Detached blocks] Fix multipage table  not breaing at the end of page, when absolutePosition arguments are included

### DIFF
--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -143,7 +143,6 @@ DocumentContext.prototype.beginDetachedBlock = function() {
 		availableHeight: this.availableHeight,
 		availableWidth: this.availableWidth,
 		page: this.page,
-		bottomMost: { y: this.y, page: this.page },
 		endingCell: this.endingCell,
 		lastColumnWidth: this.lastColumnWidth
 	});
@@ -152,12 +151,12 @@ DocumentContext.prototype.beginDetachedBlock = function() {
 DocumentContext.prototype.endDetachedBlock = function() {
 	var saved = this.snapshots.pop();
 
-	this.endingCell = null;
 	this.x = saved.x;
-	this.y = saved.bottomMost.y;
-	this.page = saved.bottomMost.page;
+	this.y = saved.y;
 	this.availableWidth = saved.availableWidth;
-	this.availableHeight = saved.bottomMost.availableHeight;
+	this.availableHeight = saved.availableHeight;
+	this.page = saved.page;
+	this.endingCell = saved.endingCell;
 	this.lastColumnWidth = saved.lastColumnWidth;
 };
 


### PR DESCRIPTION
Its seem I didn't save the context properly on absolutePostinion element, and here is the fix.

No build files, in the pull request, for easier merge. Also I think browserify config in master is broken as I cannot find any way to build working build/pdfmake.js. It is building, and looks ok, but when loaded with requireJS (trough bower), it is totally nonfunctional. 