### PR TITLE
fixes readme typo for italic style setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ var docDefinition = {
       bold: true
     },
     anotherStyle: {
-      italic: true,
+      italics: true,
       alignment: 'right'
     }
   }


### PR DESCRIPTION
I was having problems with the italics style setting... the problem was the readme docs for it. The setting should be *italics* no *italic*.