### PR TITLE
Fix IE10 issue with __defineGetter__

### DIFF
--- a/src/fontWrapper.js
+++ b/src/fontWrapper.js
@@ -12,13 +12,17 @@ function FontWrapper(pdfkitDoc, path, fontName){
 	this.charCatalogue = [];
 	this.name = fontName;
 
-  this.__defineGetter__('ascender', function(){
-    var font = this.getFont(0);
-    return font.ascender;
+  Object.defineProperty(this, 'ascender', {
+    get: function () {
+      var font = this.getFont(0);
+      return font.ascender;
+    }
   });
-  this.__defineGetter__('decender', function(){
-    var font = this.getFont(0);
-    return font.decender;
+  Object.defineProperty(this, 'decender', {
+    get: function () {
+      var font = this.getFont(0);
+      return font.decender;
+    }
   });
 
 }


### PR DESCRIPTION
This commit changes `fontWrapper.js` to use the standardized `defineProperty` function instead of `__defineGetter__` which is not supported in Internet Explorer 10 and lower.