### PR TITLE
Fix autoPrint in Chrome & FF by using Named OpenAction instead JS Action

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -104,20 +104,13 @@ PdfPrinter.prototype.createPdfKitDocument = function(docDefinition, options) {
 	renderPages(pages, this.fontProvider, this.pdfKitDoc);
 
 	if(options.autoPrint){
-        var jsRef = this.pdfKitDoc.ref({
-			S: 'JavaScript',
-			JS: new StringObject('this.print\\(true\\);')
-		});
-		var namesRef = this.pdfKitDoc.ref({
-			Names: [new StringObject('EmbeddedJS'), new PDFReference(this.pdfKitDoc, jsRef.id)],
-		});
-
-		jsRef.end();
-		namesRef.end();
-
-		this.pdfKitDoc._root.data.Names = {
-			JavaScript: new PDFReference(this.pdfKitDoc, namesRef.id)
-		};
+    var printActionRef = this.pdfKitDoc.ref({
+      Type: 'Action',
+      S: 'Named',
+      N: 'Print'
+    });
+    this.pdfKitDoc._root.data.OpenAction = printActionRef;
+    printActionRef.end();
 	}
 	return this.pdfKitDoc;
 };


### PR DESCRIPTION
Code that devongovett considered implementing directly into pdfkit but didn't. [pdfkit issue 217](https://github.com/devongovett/pdfkit/issues/217). This makes autoprint work, and thus ```.print()``` also works. Haven't tried in IE because of missing datauri support.