### PR TITLE
Add noWrap feature

### DIFF
--- a/dev-playground/public/samples/tables
+++ b/dev-playground/public/samples/tables
@@ -72,6 +72,24 @@ content: [
 							]
 					}
 			},
+			{
+					style: 'tableExample',
+					table: {
+							widths: ['*', 'auto'],
+							body: [
+									[ 'This is a star-sized column. The next column over, an auto-sized column, will wrap to accomodate all the text in this cell.', 'I am auto sized.'],
+							]
+					}
+			},
+			{
+					style: 'tableExample',
+					table: {
+							widths: ['*', 'auto'],
+							body: [
+									[ 'This is a star-sized column. The next column over, an auto-sized column, will not wrap to accomodate all the text in this cell, because it has been given the noWrap style.', { text: 'I am auto sized.', noWrap: true } ],
+							]
+					}
+			},
 			{ text: 'Headers', style: 'subheader' },
 			'You can declare how many rows should be treated as a header. Headers are automatically repeated on the following pages',
 			{ text: [ 'It is also possible to set keepWithHeaderRows to make sure there will be no page-break between the header and these rows. Take a look at the document-definition and play with it. If you set it to one, the following table will automatically start on the next page, since there\'s not enough space for the first row to be rendered here' ], color: 'gray', italics: true },

--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -175,7 +175,13 @@ DocMeasure.prototype.measureImage = function(node) {
 };
 
 DocMeasure.prototype.measureLeaf = function(node) {
-	var data = this.textTools.buildInlines(node.text, this.styleStack);
+
+	// Make sure style properties of the node itself are considered when building inlines.
+	// We could also just pass [node] to buildInlines, but that fails for bullet points.
+	var styleStack = this.styleStack.clone();
+	styleStack.push(node);
+
+	var data = this.textTools.buildInlines(node.text, styleStack);
 
 	node._inlines = data.items;
 	node._minWidth = data.minWidth;

--- a/src/styleContextStack.js
+++ b/src/styleContextStack.js
@@ -94,7 +94,8 @@ StyleContextStack.prototype.autopush = function(item) {
 		'decorationStyle',
 		'decorationColor',
 		'background',
-		'lineHeight'
+		'lineHeight',
+		'noWrap'
 		//'tableCellPadding'
 		// 'cellBorder',
 		// 'headerCellBorder',

--- a/src/textTools.js
+++ b/src/textTools.js
@@ -49,6 +49,10 @@ TextTools.prototype.buildInlines = function(textArray, styleContextStack) {
 		}
 	});
 
+	if (getStyleProperty({}, styleContextStack, 'noWrap', false)) {
+		minWidth = maxWidth;
+	}
+
 	return {
 		items: measured,
 		minWidth: minWidth,
@@ -88,12 +92,16 @@ TextTools.prototype.sizeOfString = function(text, styleContextStack) {
 	};
 };
 
-function splitWords(text) {
+function splitWords(text, noWrap) {
 	var results = [];
 	text = text.replace('\t', '    ');
 
-	var array = text.match(WORD_RE);
-
+	var array;
+	if (noWrap) {
+		array = [ text, "" ];
+	} else {
+		array = text.match(WORD_RE);
+	}
 	// i < l - 1, because the last match is always an empty string
 	// other empty strings however are treated as new-lines
 	for(var i = 0, l = array.length; i < l - 1; i++) {
@@ -115,7 +123,6 @@ function splitWords(text) {
 			}
 		}
 	}
-
 	return results;
 }
 
@@ -147,7 +154,7 @@ function normalizeTextArray(array) {
 		if (typeof item == 'string' || item instanceof String) {
 			words = splitWords(item);
 		} else {
-			words = splitWords(item.text);
+			words = splitWords(item.text, item.noWrap);
 			style = copyStyle(item);
 		}
 

--- a/tests/textTools.js
+++ b/tests/textTools.js
@@ -54,6 +54,20 @@ describe('TextTools', function() {
 		' Nowak Dodatkowe informacje:'
 	];
 
+	var mixedTextArrayWithoutNewLinesNoWrapLongest = [
+		'Imię: ',
+		'Jan   ',
+		'   Nazwisko:',
+		{ text: ' Nowak Dodatkowe informacje:', noWrap: true }
+	];
+
+	var mixedTextArrayWithoutNewLinesNoWrapShortest = [
+		'Imię: ',
+		{ text: 'Jan   ', noWrap: true },
+		'   Nazwisko:',
+		' Nowak Dodatkowe informacje:'
+	];
+
 	var plainTextArrayWithoutNewLinesWhichRequiresTrimming = [
 		'                          Imię: ',
 		'Jan   ',
@@ -87,7 +101,7 @@ describe('TextTools', function() {
 		bold: false,
 		font: 'Helvetica'
 	});
-
+	var styleStackNoWrap = new StyleContextStack({}, { noWrap: true });
 
 	describe('splitWords', function() {
 		it('should do basic splitting', function() {
@@ -286,6 +300,25 @@ describe('TextTools', function() {
 			var inlines = textTools.buildInlines(textArrayWithNewLinesWhichRequiresTrimming);
 			assert.equal(inlines.maxWidth, 21 * 12);
 		});
+
+		it('should set min width to max when nowrap style is specified', function(){
+			var inlines = textTools.buildInlines(plainTextArrayWithoutNewLines,styleStackNoWrap);
+			assert.equal(inlines.minWidth, 52 * 12);
+			assert.equal(inlines.maxWidth, 52 * 12);
+		});
+
+		it('should set min width to longest when nowrap style is specified on longest segment', function(){
+			var inlines = textTools.buildInlines(mixedTextArrayWithoutNewLinesNoWrapLongest);
+			assert.equal(inlines.minWidth, 27 * 12);
+			assert.equal(inlines.maxWidth, 52 * 12);
+		});
+
+		it('should set widths to normal when nowrap style is specified on shortest segment', function(){
+			var inlines = textTools.buildInlines(mixedTextArrayWithoutNewLinesNoWrapShortest);
+			assert.equal(inlines.minWidth, 11 * 12);
+			assert.equal(inlines.maxWidth, 52 * 12);
+		});
+
 	});
 
 	describe('sizeOfString', function() {


### PR DESCRIPTION
If you have a two-column table, with a description in the first column, and currency in the second column, and if the description is very long, you could end up with the currency going from:
    $12,345.67
to:
    $12,
    345.
   67
To prevent this, add a noWrap style to the currency column: { noWrap: true, text: "$12,345.67" }
