### PR TITLE
DocMeasure.prototype.measureNode fix empty node

### DIFF
--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -37,6 +37,12 @@ DocMeasure.prototype.measureNode = function(node) {
 	} else if (typeof node == 'string' || node instanceof String) {
 		node = { text: node };
 	}
+	
+	// Deal with empty nodes to prevent crash in getNodeMargin
+	if (Object.keys(node).length === 0) {
+		// A warning could be logged: console.warn('pdfmake: Empty node, ignoring it');
+		node = { text: '' };
+	}
 
 	var self = this;
 


### PR DESCRIPTION
When `DocMeasure.prototype.measureNode` receives an empty object as node pdfmake will throw an error: `Unrecognized document structure: {"_margin":null}`
I would prefer:
 * ignore the empty node
 * log a warning in the console
 * continue and try to generate the PDF.