### PR TITLE
Don't create pdfmake object if browser doesn't support required APIs

### DIFF
--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -3,6 +3,11 @@
 /* global BlobBuilder */
 'use strict';
 
+// Ensure the browser provides the level of support needed
+if ( ! Object.keys ) {
+	return;
+}
+
 var PdfPrinter = require('../printer');
 var FileSaver = require('../../libs/FileSaver.js/FileSaver');
 var saveAs = FileSaver.saveAs;


### PR DESCRIPTION
If you load pdfmake in IE8- you get an error on the page because it doesn't provide `Object.keys`. While I don't propose that pdfmake should support these legacy browsers (!) it would be great if simply loading the file didn't cause them to throw a Javascript error, stopping all other Javascript execution.

While it would be easy to have pdfmake included with conditional comments if it were being loaded as a single file, that isn't so easy where concatenation of libraries is used. This little change just sidesteps it.