### PR TITLE
Allow to specify CreationDate property so its possible to automatic test pdf generation

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -101,6 +101,7 @@ PdfPrinter.prototype.createPdfKitDocument = function(docDefinition, options) {
 		this.pdfKitDoc.info.Author = docDefinition.info.author ? docDefinition.info.author : null;
 		this.pdfKitDoc.info.Subject = docDefinition.info.subject ? docDefinition.info.subject : null;
 		this.pdfKitDoc.info.Keywords = docDefinition.info.keywords ? docDefinition.info.keywords : null;
+		this.pdfKitDoc.info.CreationDate = docDefinition.info.creationDate ? docDefinition.info.creationDate : null;
 	}
 	
 	this.fontProvider = new FontProvider(this.fontDescriptors, this.pdfKitDoc);


### PR DESCRIPTION
This is to allow automatic testing of pdf generation via its hash sum. Having a non fixed value for creation date will make it impossible to grant a constant hash for the same pdf file.