### PR TITLE
Table fix - dontBreakRows and fillColor

### DIFF
--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -212,7 +212,7 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
           if(fillColor ) {
             var wBorder = this.layout.vLineWidth(colIndex, this.tableNode);
             var xf = xs[i].x+wBorder;
-            var yf = this.dontBreakRows ? hzLineOffset : y1 - hzLineOffset;
+            var yf = this.dontBreakRows ? y1 : y1 - hzLineOffset;
             writer.addVector({
               type: 'rect',
               x: xf,
@@ -264,6 +264,7 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
     if(this.dontBreakRows) {
       writer.tracker.auto('pageChanged',
         function() {
+          self.drawHorizontalLine(rowIndex, writer);
         },
         function() {
           writer.commitUnbreakableBlock();

--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -212,7 +212,7 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
           if(fillColor ) {
             var wBorder = this.layout.vLineWidth(colIndex, this.tableNode);
             var xf = xs[i].x+wBorder;
-            var yf = y1 - hzLineOffset;
+            var yf = this.dontBreakRows ? hzLineOffset : y1 - hzLineOffset;
             writer.addVector({
               type: 'rect',
               x: xf,
@@ -264,11 +264,9 @@ TableProcessor.prototype.endRow = function(rowIndex, writer, pageBreaks) {
     if(this.dontBreakRows) {
       writer.tracker.auto('pageChanged',
         function() {
-          self.drawHorizontalLine(rowIndex, writer);
         },
         function() {
           writer.commitUnbreakableBlock();
-          self.drawHorizontalLine(rowIndex, writer);
         }
       );
     }

--- a/tests/tableProcessor.js
+++ b/tests/tableProcessor.js
@@ -86,7 +86,7 @@ describe('TableProcessor', function () {
     processor.beginRow(0, writerFake);
     processor.endRow(0, writerFake, []);
 
-    assert.equal(addVectorCallCount, 4)
+    assert.equal(addVectorCallCount, 3)
   });
 
   it('should use the line colors constants (regression #161)', function () {
@@ -117,7 +117,7 @@ describe('TableProcessor', function () {
     processor.beginRow(0, writerFake);
     processor.endRow(0, writerFake, []);
 
-    assert.equal(addVectorCallCount, 4);
+    assert.equal(addVectorCallCount, 3);
   });
 
   describe('header with nested table (issue #199)', function () {

--- a/tests/tableProcessor.js
+++ b/tests/tableProcessor.js
@@ -86,7 +86,7 @@ describe('TableProcessor', function () {
     processor.beginRow(0, writerFake);
     processor.endRow(0, writerFake, []);
 
-    assert.equal(addVectorCallCount, 3)
+    assert.equal(addVectorCallCount, 4)
   });
 
   it('should use the line colors constants (regression #161)', function () {
@@ -117,7 +117,7 @@ describe('TableProcessor', function () {
     processor.beginRow(0, writerFake);
     processor.endRow(0, writerFake, []);
 
-    assert.equal(addVectorCallCount, 3);
+    assert.equal(addVectorCallCount, 4);
   });
 
   describe('header with nested table (issue #199)', function () {


### PR DESCRIPTION
fix for issues #450, #158
Fix bugs in table fillColor and draw horizontal line if is `dontBreakRows` enabled.
