### PR TITLE
Catch malformed row error

### DIFF
--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -306,6 +306,10 @@ DocMeasure.prototype.measureTable = function(node) {
 		for(row = 0, rows = node.table.body.length; row < rows; row++) {
 			var rowData = node.table.body[row];
 			var data = rowData[col];
+			if(data === undefined){
+				console.error('Malformed table row ', rowData, 'in node ', node);
+				throw 'Malformed table row, a cell is undefined.';
+			}
 			if (!data._span) {
 				var _this = this;
 				data = rowData[col] = this.styleStack.auto(data, measureCb(this, data));


### PR DESCRIPTION
Hey,
When a table row have an undefined cell, 
``` if (!data._span) { ``` produce an exception.

When you have a lot of array in a pdf, it s totaly insame to debug it.
I suggest to catch it and throw some information to help the dev to debug that.