### PR TITLE
Add composer.json to maintain support at Packagist repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+  "name": "bpampuch/pdfmake",
+  "type": "library",
+  "description": "Client/server side PDF printing in pure JavaScript",
+  "keywords": ["pdfmake", "pdf", "javascript"],
+  "homepage": "https://github.com/bpampuch/pdfmake",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Bartek Pampuch",
+      "email": "bpampuch@pdfmake.org",
+      "homepage": "http://pdfmake.org",
+      "role": "Developer"
+    },
+    {
+      "name": "Thiago Pereira Rosa",
+      "email": "thiagor@engineer.com",
+      "homepage": "http://coderi.com.br",
+      "role": "Contributor"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/bpampuch/pdfmake/issues"
+  }
+}


### PR DESCRIPTION
Due to the importance and great use of this library, I believe that it should also be available in Packagist ([Composer] (https://getcomposer.org) dependencies manager) and not only in the [NPM](https://www.npmjs.com) as usual.

If accepted my Pull Request, I will send the configuration data to enable webhook to keep the library always updated with this original repository.

Thank you for the commitment to keep this active project. =)