### PR TITLE
Prevent script from crashing when using integers

### DIFF
--- a/src/textTools.js
+++ b/src/textTools.js
@@ -94,7 +94,7 @@ TextTools.prototype.sizeOfString = function(text, styleContextStack) {
 
 function splitWords(text, noWrap) {
 	var results = [];
-	text = text.replace('\t', '    ');
+	text = text.toString().replace('\t', '    ');
 
 	var array;
 	if (noWrap) {


### PR DESCRIPTION
It took me quite a while to figure out why I kept seeing "text.replace is not a function". In the end I figured out that it was because pdfMake was trying to call a .replace on a integer. This fixes that and now allowes integers (along with other types that have the .toString() method)

Example:

`
{
    columns: [{
        table: {
            body: [
                'Hello world',
                123
            ]
        }
    }]
}
`
