### PR TITLE
Added toString() to splitWords function

### DIFF
--- a/src/textTools.js
+++ b/src/textTools.js
@@ -94,7 +94,7 @@ TextTools.prototype.sizeOfString = function(text, styleContextStack) {
 
 function splitWords(text, noWrap) {
 	var results = [];
-	text = text.replace('\t', '    ');
+	text = text.toString().replace('\t', '    ');
 
 	var array;
 	if (noWrap) {


### PR DESCRIPTION
This prevents everything from crashing when using integers or floats. Much better than having to call toString() on every single number that we put on our pdf.
