### PR TITLE
Add support for TrueType Collection (.ttc)

### DIFF
--- a/src/fontProvider.js
+++ b/src/fontProvider.js
@@ -45,7 +45,11 @@ FontProvider.prototype.provideFont = function (familyName, bold, italics) {
 	this.fontCache[familyName] = this.fontCache[familyName] || {};
 
 	if (!this.fontCache[familyName][type]) {
-		this.fontCache[familyName][type] = this.pdfDoc.font(this.fonts[familyName][type])._font;
+		var def = this.fonts[familyName][type];
+		if (!Array.isArray(def)) {
+			def = [def];
+		}
+		this.fontCache[familyName][type] = this.pdfDoc.font.apply(this.pdfDoc, def)._font;
 	}
 
 	return this.fontCache[familyName][type];


### PR DESCRIPTION
Can use *.ttc fonts now.

For example:

```js
var fonts = {
  // use normal fonts
  Roboto: {
    normal: 'fonts/Roboto-Regular.ttf',
    bold: 'fonts/Roboto-Medium.ttf',
    italics: 'fonts/Roboto-Italic.ttf',
    bolditalics: 'fonts/Roboto-Italic.ttf'
  },
  // use fonts in colleciton
  PingFangSC: {
    normal: ['fonts/pingfang.ttc', 'PingFangSC-Regular'],
    bold: ['fonts/pingfang.ttc', 'PingFangSC-Semibold'],
  }
};

var PdfPrinter = require('../src/printer');
var printer = new PdfPrinter(fonts);
var fs = require('fs');

var docDefinition = {
  content: [
    'First paragraph',
    'Another paragraph, this time a little bit longer to make sure, this line will be divided into at least two lines'
  ],
  defaultStyle: {
    font: 'PingFangSC',
    fontSize: 12
  }
};

var pdfDoc = printer.createPdfKitDocument(docDefinition);
pdfDoc.pipe(fs.createWriteStream('pdfs/basics.pdf'));
pdfDoc.end();

```