### PR TITLE
feat (printer) Add progress callback option

### DIFF
--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -95,8 +95,10 @@ Document.prototype._openWindow = function () {
 	return win;
 };
 
-Document.prototype.open = function () {
+Document.prototype.open = function (options) {
 	var win = this._openWindow();
+
+	options.autoPrint = false;
 
 	try {
 		var that = this;
@@ -105,7 +107,7 @@ Document.prototype.open = function () {
 			var urlCreator = window.URL || window.webkitURL;
 			var pdfUrl = urlCreator.createObjectURL(blob);
 			win.location.href = pdfUrl;
-		}, {autoPrint: false});
+		}, options);
 	} catch (e) {
 		win.close();
 		throw e;
@@ -113,8 +115,10 @@ Document.prototype.open = function () {
 };
 
 
-Document.prototype.print = function () {
+Document.prototype.print = function (options) {
 	var win = this._openWindow();
+
+	options.autoPrint = true;
 
 	try {
 		var that = this;
@@ -123,14 +127,14 @@ Document.prototype.print = function () {
 			var urlCreator = window.URL || window.webkitURL;
 			var pdfUrl = urlCreator.createObjectURL(blob);
 			win.location.href = pdfUrl;
-		}, {autoPrint: true});
+		}, options);
 	} catch (e) {
 		win.close();
 		throw e;
 	}
 };
 
-Document.prototype.download = function (defaultFileName, cb) {
+Document.prototype.download = function (defaultFileName, cb, options) {
 	if (typeof defaultFileName === 'function') {
 		cb = defaultFileName;
 		defaultFileName = null;
@@ -145,7 +149,7 @@ Document.prototype.download = function (defaultFileName, cb) {
 		if (typeof cb === 'function') {
 			cb();
 		}
-	});
+	}, options);
 };
 
 Document.prototype.getBase64 = function (cb, options) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -110,7 +110,7 @@ PdfPrinter.prototype.createPdfKitDocument = function (docDefinition, options) {
 		this.pdfKitDoc.options.size = [pageSize.width, pageHeight];
 	}
 
-	renderPages(pages, this.fontProvider, this.pdfKitDoc);
+	renderPages(pages, this.fontProvider, this.pdfKitDoc, options.progressCallback);
 
 	if (options.autoPrint) {
 		var printActionRef = this.pdfKitDoc.ref({
@@ -265,9 +265,14 @@ function updatePageOrientationInOptions(currentPage, pdfKitDoc) {
 	}
 }
 
-function renderPages(pages, fontProvider, pdfKitDoc) {
+function renderPages(pages, fontProvider, pdfKitDoc, progressCallback) {
 	pdfKitDoc._pdfMakePages = pages;
 	pdfKitDoc.addPage();
+
+	var totalItems = progressCallback && _.sumBy(pages, function(page) { return page.items.length; });
+	var renderedItems = 0;
+	progressCallback = progressCallback || function() {};
+	
 	for (var i = 0; i < pages.length; i++) {
 		if (i > 0) {
 			updatePageOrientationInOptions(pages[i], pdfKitDoc);
@@ -288,6 +293,8 @@ function renderPages(pages, fontProvider, pdfKitDoc) {
 					renderImage(item.item, item.item.x, item.item.y, pdfKitDoc);
 					break;
 			}
+			renderedItems++;
+			progressCallback(renderedItems / totalItems);
 		}
 		if (page.watermark) {
 			renderWatermark(page, pdfKitDoc);

--- a/tests/printer.js
+++ b/tests/printer.js
@@ -224,4 +224,54 @@ describe('Printer', function () {
     assert(Pdfkit.prototype.addPage.callCount === 3);
   });
 
+	it('should report progress on each rendered item when a progressCallback is passed', function () {
+
+    printer = new Printer(fontDescriptors);
+
+		var progressCallback = sinon.spy(function(progress) {});
+
+    var docDefinition = {
+      pageSize: 'A4',
+      content: [
+        {
+          text: 'Text item 1'
+        },
+				{
+					image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAGAQMAAADNIO3CAAAAA1BMVEUAAN7GEcIJAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB98DBREbA3IZ3d8AAAALSURBVAjXY2BABwAAEgAB74lUpAAAAABJRU5ErkJggg=='
+				},
+        {
+          text: 'Text item 2'
+        },
+				{
+					canvas: [{
+						type: 'rect',
+						x: 0,
+						y: 0,
+						w: 310,
+						h: 260
+					}]
+				}]
+    };
+
+    printer.createPdfKitDocument(docDefinition, {progressCallback: progressCallback});
+
+    assert(progressCallback.withArgs(0.25).calledOnce);
+		assert(progressCallback.withArgs(0.5).calledOnce);
+		assert(progressCallback.withArgs(0.75).calledOnce);
+    assert(progressCallback.withArgs(1).calledOnce);
+	});
+
+	it('should work without a progressCallback', function() {
+		printer = new Printer(fontDescriptors);
+
+    var docDefinition = {
+      pageSize: 'A4',
+      content: [ { text: 'Text item 1' } ]
+		};
+
+    assert.doesNotThrow(function() {
+			printer.createPdfKitDocument(docDefinition)
+		});
+	});
+
 });


### PR DESCRIPTION
I want to resolve #837 by adding an optional progress callback to `PdfPrinter.createPdfKitDocument`. The callback is called with the current progress every time an item is rendered into the pdfKitDoc.