### PR TITLE
Update main property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pdfmake",
   "version": "0.1.28",
   "description": "Client/server side PDF printing in pure JavaScript",
-  "main": "src/printer.js",
+  "main": "build/pdfmake.js",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
This fixes the *problem* with ES6.

Instead of using:

```js
import pdfMake from 'pdfmake/build/pdfmake'
```
You can import now like this:
```js
import pdfMake from 'pdfmake'
```
No need to add extra `build/pdfmake` path during importing as ES6 module. 