### PR TITLE
Allow oversized images if they are the only item on a page

### DIFF
--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -92,7 +92,7 @@ ElementWriter.prototype.addImage = function (image, index) {
 	var page = context.getCurrentPage(),
 		position = this.getCurrentPositionOnPage();
 
-	if (context.availableHeight < image._height || !page) {
+	if (!page || (context.availableHeight < image._height && page.items.length > 0)) {
 		return false;
 	}
 


### PR DESCRIPTION
This should fix #855 - an issue where blank pages are rendered if an image can not fit vertically on a page. If the page is empty, it will add the oversized image. If there is anything already on the page, it will add add a new page containing the oversized image.