### PR TITLE
Added an option to preserve leading whitespaces (issue #558)

### DIFF
--- a/src/textTools.js
+++ b/src/textTools.js
@@ -238,6 +238,7 @@ function measure(fontProvider, textArray, styleContextStack) {
 		var link = getStyleProperty(item, styleContextStack, 'link', null);
 		var linkToPage = getStyleProperty(item, styleContextStack, 'linkToPage', null);
 		var noWrap = getStyleProperty(item, styleContextStack, 'noWrap', null);
+		var preserveLeadingSpaces = getStyleProperty(item, styleContextStack, 'preserveLeadingSpaces', false);
 
 		var font = fontProvider.provideFont(fontName, bold, italics);
 
@@ -250,7 +251,7 @@ function measure(fontProvider, textArray, styleContextStack) {
 			item.leadingCut = 0;
 		}
 
-		if (leadingSpaces) {
+		if (leadingSpaces && !preserveLeadingSpaces) {
 			item.leadingCut += widthOfString(leadingSpaces[0], font, fontSize, characterSpacing);
 		}
 

--- a/tests/textTools.js
+++ b/tests/textTools.js
@@ -101,6 +101,10 @@ describe('TextTools', function () {
 		leadingIndent: 10
 	};
 
+	var textWithLeadingSpaces = [
+		{text: '    This is a paragraph', preserveLeadingSpaces: true}
+	];
+
 	var mixedTextArrayWithVariousTypes = [
 		{text: ''},
 		{text: null},
@@ -394,6 +398,11 @@ describe('TextTools', function () {
 			var countLeadingCut = 0;
 			inlines.items.forEach(function(item) { countLeadingCut += item.leadingCut; });
 			assert.equal(countLeadingCut, -10);
+		});
+
+		it('should preserve leading whitespaces when preserveLeadingSpaces is set', function() {
+			var inlines = textTools.buildInlines(textWithLeadingSpaces);
+			assert.equal(inlines.maxWidth, 23 * 12);
 		});
 	});
 


### PR DESCRIPTION
Added optional argument to text blocks to prevent leading spaces from being trimmed (issue #558).
Please let me know if there is something to change.
