### PR TITLE
Fix rendering after an empty list of columns

### DIFF
--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -496,8 +496,9 @@ DocMeasure.prototype.measureColumns = function (node) {
 
 	var measures = ColumnCalculator.measureMinMax(columns);
 
-	node._minWidth = measures.min + node._gap * (columns.length - 1);
-	node._maxWidth = measures.max + node._gap * (columns.length - 1);
+	var numGaps = (columns.length > 0) ? (columns.length - 1) : 0;
+	node._minWidth = measures.min + node._gap * numGaps;
+	node._maxWidth = measures.max + node._gap * numGaps;
 
 	return node;
 };

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -33,7 +33,13 @@ DocumentContext.prototype.beginColumnGroup = function () {
 		availableHeight: this.availableHeight,
 		availableWidth: this.availableWidth,
 		page: this.page,
-		bottomMost: {y: this.y, page: this.page},
+		bottomMost: {
+			x: this.x,
+			y: this.y,
+			availableHeight: this.availableHeight,
+			availableWidth: this.availableWidth,
+			page: this.page
+		},
 		endingCell: this.endingCell,
 		lastColumnWidth: this.lastColumnWidth
 	});

--- a/tests/integration/columns.js
+++ b/tests/integration/columns.js
@@ -221,6 +221,21 @@ describe('Integration test: columns', function () {
 		assert.deepEqual(testHelper.getInlineTexts(pages, {page: 0, item: 1}).join(''), 'val');
 	});
 
+	it('renders empty column lists', function () {
+		var dd = {
+			content: [
+				{ columns: [] },
+				{ columns: [
+					{ text: _.map(new Array(80), () => 'Lorem ipsum') }
+				]
+				},
+			]
+		};
+		var pages = testHelper.renderPages('A6', dd);
+
+		assert.deepEqual(pages.length, 2);
+	});
+
 	it('render nested columns', function () {
 		var dd = {
 			content: [


### PR DESCRIPTION
Page breaks aren't inserted correctly after elements with 0 columns.
Also fix calculation resulting in negative widths with 0 columns.