### PR TITLE
Add word breaking to columns

### DIFF
--- a/src/columnCalculator.js
+++ b/src/columnCalculator.js
@@ -42,18 +42,25 @@ function buildColumnWidths(columns, availableWidth) {
 	// http://www.w3.org/TR/CSS2/tables.html#width-layout
 	// http://dev.w3.org/csswg/css3-tables-algorithms/Overview.src.htm
 	var minW = autoMin + starMaxMin * starColumns.length;
+	var availableMinW = Math.floor((availableWidth - autoMin) / starColumns.length);
 	var maxW = autoMax + starMaxMax * starColumns.length;
 	if (minW >= availableWidth) {
 		// case 1 - there's no way to fit all columns within available width
 		// that's actually pretty bad situation with PDF as we have no horizontal scroll
-		// no easy workaround (unless we decide, in the future, to split single words)
-		// currently we simply use minWidths for all columns
+		// we leave auto columns with their minWidth
 		autoColumns.forEach(function (col) {
 			col._calcWidth = col._minWidth;
 		});
 
+		// for star columns we go down to the bare minimum
+		// if noWrap isn't set, then we can break single words
+		// otherwise we simply use minWidths for all star columns
 		starColumns.forEach(function (col) {
-			col._calcWidth = starMaxMin; // starMaxMin already contains padding
+			if (col.noWrap) {
+				col._calcWidth = starMaxMin; // starMaxMin already contains padding
+			} else {
+				col._calcWidth = availableMinW;
+			}
 		});
 	} else {
 		if (maxW < availableWidth) {

--- a/src/textTools.js
+++ b/src/textTools.js
@@ -245,7 +245,7 @@ function measure(fontProvider, textArray, styleContextStack) {
 		item.height = font.lineHeight(fontSize) * lineHeight;
 
 		var leadingSpaces = item.text.match(LEADING);
-		
+
 		if (!item.leadingCut) {
 			item.leadingCut = 0;
 		}

--- a/tests/columnCalculator.js
+++ b/tests/columnCalculator.js
@@ -77,7 +77,8 @@ describe('ColumnCalculator', function () {
 			});
 		});
 
-		it('should set calcWidth of star columns to largest star min-width if there is not enough space for the table', function () {
+		it('should set calcWidth of star columns to availableSpace distributed across star'+
+			'columns if there is not enough space for the table', function () {
 			var columns = [
 				{width: 'auto', _minWidth: 300, _maxWidth: 410},
 				{width: '*', _minWidth: 301, _maxWidth: 420},
@@ -86,8 +87,8 @@ describe('ColumnCalculator', function () {
 
 			ColumnCalculator.buildColumnWidths(columns, 320);
 			assert.equal(columns[0]._calcWidth, columns[0]._minWidth);
-			assert.equal(columns[1]._calcWidth, 303);
-			assert.equal(columns[2]._calcWidth, 303);
+			assert.equal(columns[1]._calcWidth, 10);
+			assert.equal(columns[2]._calcWidth, 10);
 		});
 
 		it('should make columns wider proportionally if table can fit within the available space', function () {

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -627,27 +627,35 @@ describe('LayoutBuilder', function () {
 				}
 			];
 
+			var fontSize = 12;
 			var pages = builder.layoutDocument(desc, sampleTestProvider, {
 				header: {
 					italics: true,
-					fontSize: 50
+					fontSize: fontSize
 				}
 			});
 
 			assert.equal(pages.length, 1);
-			assert.equal(pages[0].items.length, 5);
+			assert.equal(pages[0].items.length, 10);
+
 			assert.equal(pages[0].items[0].item.x, pages[0].items[1].item.x);
 			assert.equal(pages[0].items[1].item.x, pages[0].items[2].item.x);
 
-			assert.equal(pages[0].items[0].item.y, pages[0].items[3].item.y);
-			assert.equal(pages[0].items[0].item.y, pages[0].items[4].item.y);
+			assert.equal(pages[0].items[0].item.y, pages[0].items[6].item.y);
+			assert.equal(pages[0].items[0].item.y, pages[0].items[8].item.y);
 
-			assert.equal(pages[0].items[0].item.inlines[0].width, 9 * 50 * 1.5);
-			assert.equal(pages[0].items[1].item.inlines[0].width, 10 * 50 * 1.5);
+			assert.equal(pages[0].items[0].item.inlines[0].width, 5 * fontSize * 1.5);
+			assert.equal(pages[0].items[1].item.inlines[0].width, 4 * fontSize * 1.5);
+			assert.equal(pages[0].items[2].item.inlines[0].width, 5 * fontSize * 1.5);
+			assert.equal(pages[0].items[3].item.inlines[0].width, 5 * fontSize * 1.5);
+			assert.equal(pages[0].items[4].item.inlines[0].width, 8 * fontSize);
+			assert.equal(pages[0].items[5].item.inlines[0].width, 2 * fontSize);
 
-			assert.equal(pages[0].items[2].item.inlines[0].width, 10 * 50);
-			assert.equal(pages[0].items[3].item.inlines[0].width, 8 * 50);
-			assert.equal(pages[0].items[4].item.inlines[0].width, 6 * 50);
+			assert.equal(pages[0].items[6].item.inlines[0].width, 8 * fontSize);
+			assert.equal(pages[0].items[7].item.inlines[0].width, 6 * fontSize);
+
+			assert.equal(pages[0].items[8].item.inlines[0].width, 6 * fontSize);
+			assert.equal(pages[0].items[9].item.inlines[0].width, 6 * fontSize);
 		});
 
 		it('should support unordered lists', function () {
@@ -1264,6 +1272,20 @@ describe('LayoutBuilder', function () {
 			var pages = builder.layoutDocument(desc, sampleTestProvider);
 			assert.equal(pages[0].items.length, 3);
 		});
+
+		it('should support wrap long word in columns', function () {
+			var desc = [
+				{ columns: [
+					{ width: "*",
+						text: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
+					}
+				]}
+			];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+			assert.equal(pages[0].items.length, 3);
+		});
+
 
 		it('should support wrap long word with big font size', function () {
 			var desc = [


### PR DESCRIPTION
Star columns are given the absolute minimum width if there would otherwise be page overflow, potentially breaking inside words.

This changes expected behavior, but I have a use case where it's very important to be sure that all content is displayed on the page, even if it looks terrible.

What do you think? Feel free to play around with the dev-playground.