### PR TITLE
Fix Table top line being put on both previous and current page #995

### DIFF
--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -34,7 +34,7 @@ TableProcessor.prototype.beginTable = function (writer) {
 	// update the border properties of all cells before drawing any lines
 	prepareCellBorders(this.tableNode.table.body);
 
-	this.drawHorizontalLine(0, writer);
+	writer.context().moveDown(this.layout.hLineWidth(0, this.tableNode));
 
 	function getTableInnerContentWidth() {
 		var width = 0;
@@ -267,6 +267,17 @@ TableProcessor.prototype.endRow = function (rowIndex, writer, pageBreaks) {
 	ys[ys.length - 1].y1 = endingY;
 
 	var skipOrphanePadding = (ys[0].y1 - ys[0].y0 === this.rowPaddingTop);
+
+	if (rowIndex == 0) {
+		if (!skipOrphanePadding) {
+			writer.context().page = ys[0].page;
+			var lineWidth = this.layout.hLineWidth(0, this.tableNode);
+			this.drawHorizontalLine(0, writer, this.rowTopY - lineWidth);
+		} else if (ys.length > 0) {
+			this.drawHorizontalLine(0, writer, ys[1].y0);
+		}
+	}
+
 	for (var yi = (skipOrphanePadding ? 1 : 0), yl = ys.length; yi < yl; yi++) {
 		var willBreak = yi < ys.length - 1;
 		var rowBreakWithoutHeader = (yi > 0 && !this.headerRows);


### PR DESCRIPTION
Another attempt to fix this bug (#995) .

On tableProcessor.js:37 beginTable() I had to
```writer.context().moveDown(this.layout.hLineWidth(0, this.tableNode));```
instead of the original:
```this.drawHorizontalLine(0, writer);```
to preserve a "top padding" that was added because beginTable() method would always draw an initial top border for the table.
I am unsure wether this "padding" was intended or not, the line 37 could be removed but it would then break tests.