### PR TITLE
Add support for inline images

### DIFF
--- a/src/docMeasure.js
+++ b/src/docMeasure.js
@@ -17,7 +17,7 @@ var qrEncoder = require('./qrEnc.js');
  * @private
  */
 function DocMeasure(fontProvider, styleDictionary, defaultStyle, imageMeasure, tableLayouts, images) {
-	this.textTools = new TextTools(fontProvider);
+	this.textTools = new TextTools(fontProvider, this);
 	this.styleStack = new StyleContextStack(styleDictionary, defaultStyle);
 	this.imageMeasure = imageMeasure;
 	this.tableLayouts = tableLayouts;

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -657,7 +657,7 @@ LayoutBuilder.prototype.buildNextLine = function (textNode) {
 	while (textNode._inlines && textNode._inlines.length > 0 && line.hasEnoughSpaceForInline(textNode._inlines[0])) {
 		var inline = textNode._inlines.shift();
 
-		if (!inline.noWrap && inline.text.length > 1 && inline.width > line.maxWidth) {
+		if (!inline.noWrap && (!inline.text || inline.text.length > 1) && inline.width > line.maxWidth) {
 			var widthPerChar = inline.width / inline.text.length;
 			var maxChars = Math.floor(line.maxWidth / widthPerChar);
 			if (maxChars < 1) {

--- a/src/line.js
+++ b/src/line.js
@@ -19,7 +19,7 @@ Line.prototype.getAscenderHeight = function () {
 	var y = 0;
 
 	this.inlines.forEach(function (inline) {
-		y = Math.max(y, inline.font.ascender / 1000 * inline.fontSize);
+		y = Math.max(y, inline.font.ascender / 1000 * (inline.image ? inline._height : inline.fontSize));
 	});
 	return y;
 };

--- a/src/printer.js
+++ b/src/printer.js
@@ -402,7 +402,11 @@ function renderLine(line, x, y, pdfKitDoc) {
 
 		pdfKitDoc._font = inline.font;
 		pdfKitDoc.fontSize(inline.fontSize);
-		pdfKitDoc.text(inline.text, x + inline.x, y + shiftToBaseline, options);
+                if (inline.image) {
+		        pdfKitDoc.image(inline.image, x + inline.x, y, {width: inline.width});
+                } else {
+		        pdfKitDoc.text(inline.text, x + inline.x, y + shiftToBaseline, options);
+                }
 
 		if (inline.linkToPage) {
 			var _ref = pdfKitDoc.ref({Type: 'Action', S: 'GoTo', D: [inline.linkToPage, 0, 0]}).end();

--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -211,10 +211,11 @@ TableProcessor.prototype.drawVerticalLine = function (x, y0, y1, vLineIndex, wri
 	if (width === 0) {
 		return;
 	}
+        var cx = x + width / 2;
 	writer.addVector({
 		type: 'line',
-		x1: x + width / 2,
-		x2: x + width / 2,
+		x1: cx,
+		x2: cx,
 		y1: y0,
 		y2: y1,
 		lineWidth: width,


### PR DESCRIPTION
This is related to #358

The result is this:  [fluid-layout.pdf](https://github.com/bpampuch/pdfmake/files/1733653/fluid-layout.pdf)

The source is:
```js
const docDefinition = {
    pageSize: 'A4',
    pageMargins: [24, 25, 24, 23],
    content: [
        {text: ['hello', {image: 'smile'}, {text: 'world', style: 'em'}]}
    ],
    styles: {
        em: {bold: true}
    },
    images
}
```