### PR TITLE
Pass pageSize as second argument to background handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ It may contain any other object as well (images, tables, ...) or be dynamically 
 
 ```js
 var docDefinition = {
-  background: function(currentPage) {
-    return 'simple text on page ' + currentPage
+  background: function(currentPage, pageSize) {
+    return `page ${currentPage} with size ${pageSize.width} x ${pageSize.height}`
   },
 
   content: (...)

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -172,15 +172,17 @@ LayoutBuilder.prototype.addBackground = function (background) {
 		return background;
 	};
 
-	var pageBackground = backgroundGetter(this.writer.context().page + 1);
+	var context = this.writer.context();
+	var pageSize = context.getCurrentPage().pageSize;
+
+	var pageBackground = backgroundGetter(context.page + 1, pageSize);
 
 	if (pageBackground) {
-		var pageSize = this.writer.context().getCurrentPage().pageSize;
 		this.writer.beginUnbreakableBlock(pageSize.width, pageSize.height);
 		pageBackground = this.docPreprocessor.preprocessDocument(pageBackground);
 		this.processNode(this.docMeasure.measureDocument(pageBackground));
 		this.writer.commitUnbreakableBlock(0, 0);
-		this.writer.context().hasBackground = true;
+		context.hasBackground = true;
 	}
 };
 

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1620,18 +1620,44 @@ describe('LayoutBuilder', function () {
 			styleDictionary = {};
 		});
 
-		it('should provide the page size', function () {
+		it('should provide the current page, page count and page size', function () {
 			docStructure = ['Text'];
 			header = sinon.spy();
 			footer = sinon.spy();
+			background = sinon.spy();
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 
 			var pageSize = {width: 400, height: 800, orientation: 'portrait'};
+			assert.equal(header.getCall(0).args[0], 1);
+			assert.equal(header.getCall(0).args[1], 1);
 			assert.deepEqual(header.getCall(0).args[2], pageSize);
+
+			assert.equal(footer.getCall(0).args[0], 1);
+			assert.equal(footer.getCall(0).args[1], 1);
 			assert.deepEqual(footer.getCall(0).args[2], pageSize);
 		});
 	});
+
+  describe('dynamic background', function () {
+    var docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction;
+
+    beforeEach(function () {
+      fontProvider = sampleTestProvider;
+      styleDictionary = {};
+    });
+
+    it('should provide the current page and page size', function () {
+      docStructure = ['Text'];
+      background = sinon.spy();
+
+      builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
+
+      var pageSize = {width: 400, height: 800, orientation: 'portrait'};
+      assert.equal(background.getCall(0).args[0], 1);
+      assert.deepEqual(background.getCall(0).args[1], pageSize);
+    });
+  });
 
 	describe('dynamic page break control', function () {
 


### PR DESCRIPTION
It adds the possibility to use the page size to define the background. Also improve dynamic header/footer tests and add dynamic background test

As example, it allows to implement a page border independent of the page size or orientation like below:

```javascript
const borderMargin = 10
var dd = {
    background: function(curr, size) {
        return { canvas: [{ 
            type: 'rect', 
            x: borderMargin, 
            y: borderMargin, 
            w: size.width - borderMargin * 2, 
            h: size.height - borderMargin * 2 
          }]
        }
    },
	content: [
	    'Text on Protrait',
		{text: 'Text on Landscape', pageOrientation: 'landscape', pageBreak: 'before'},
        {text: 'Text on Landscape 2', pageOrientation: 'portrait', pageBreak: 'after'},
        'Last Page on Protrait'    
	],
	pageSize: 'A6'
}
```
In the definition above, all pages will have the same border. Changing the pageSize will not require modification to the background definition