### PR TITLE
Allow to document definition with functions in playground

### DIFF
--- a/dev-playground/public/index.html
+++ b/dev-playground/public/index.html
@@ -104,9 +104,9 @@
 			function generate() {
 				lastGen = new Date();
 
-				eval(editor.getSession().getValue());
+				var content = editor.getSession().getValue();
 
-				$http.post('/pdf', dd).
+				$http.post('/pdf', {content: content}).
 					success(function(data, status, headers, config) {
 
 						document.getElementById('pdfV').src = data;

--- a/dev-playground/server.js
+++ b/dev-playground/server.js
@@ -44,8 +44,9 @@ function createPdfBinary(pdfDoc, callback) {
 }
 
 app.post('/pdf', function (req, res) {
+  eval(req.body.content);
 
-  createPdfBinary(req.body, function(binary) {
+  createPdfBinary(dd, function(binary) {
     res.contentType('application/pdf');
     res.send(binary);
   }, function(error) {


### PR DESCRIPTION
Fixes #1202 

Evaluates definition in server instead of in client. This prevents the data loss occurred when data is serialized in POST request.