### PR TITLE
Explicitly allows to register binary data in virtual file system

### DIFF
--- a/src/browser-extensions/virtual-fs.js
+++ b/src/browser-extensions/virtual-fs.js
@@ -2,15 +2,15 @@
 
 function VirtualFileSystem() {
 	this.fileSystem = {};
-	this.baseSystem = {};
+	this.dataSystem = {};
 }
 
 VirtualFileSystem.prototype.readFileSync = function (filename) {
 	filename = fixFilename(filename);
 
-	var base64content = this.baseSystem[filename];
-	if (base64content) {
-		return new Buffer(base64content, 'base64');
+	var dataContent = this.dataSystem[filename];
+	if (dataContent) {
+		return new Buffer(dataContent, typeof dataContent === 'string' ? 'base64' : undefined);
 	}
 
 	var content = this.fileSystem[filename];
@@ -26,7 +26,7 @@ VirtualFileSystem.prototype.writeFileSync = function (filename, content) {
 };
 
 VirtualFileSystem.prototype.bindFS = function (data) {
-	this.baseSystem = data || {};
+	this.dataSystem = data || {};
 };
 
 


### PR DESCRIPTION
Currently if a binary data (e.g. ArrayBuffer instance) is registered in pdfmake.vfs it works by accident

The parameter 'base64' is passed to Buffer constructor which pass down, inside Buffer implementation, to a Uint8Array constructor as the byteOffset. Luckily seems that Uint8Array constructor works in this case but could not

This PR checks for content type when creating vfs buffer so ensure no incorrect param is passed down