### PR TITLE
Fix for background layer and table fills on multiple pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "es6": true
+    "es6": true,
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -25,7 +25,7 @@ function DocumentContext(pageSize, pageMargins) {
 
 	this.addPage(pageSize);
 
-	this.hasBackground = false;
+	this.backgroundLength = [0];
 }
 
 DocumentContext.prototype.beginColumnGroup = function () {

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -23,9 +23,9 @@ function DocumentContext(pageSize, pageMargins) {
 
 	this.tracker = new TraversalTracker();
 
-	this.addPage(pageSize);
+	this.backgroundLength = [];
 
-	this.backgroundLength = [0];
+	this.addPage(pageSize);
 }
 
 DocumentContext.prototype.beginColumnGroup = function () {
@@ -248,6 +248,7 @@ DocumentContext.prototype.moveToNextPage = function (pageOrientation) {
 DocumentContext.prototype.addPage = function (pageSize) {
 	var page = {items: [], pageSize: pageSize};
 	this.pages.push(page);
+	this.backgroundLength.push(0);
 	this.page = this.pages.length - 1;
 	this.initializePage();
 

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -154,7 +154,6 @@ LayoutBuilder.prototype.tryLayoutDocument = function (docStructure, fontProvider
 	var _this = this;
 	this.writer.context().tracker.startTracking('pageAdded', function () {
 		_this.addBackground(background);
-		_this.writer.context().backgroundLength.push(0);
 	});
 
 	this.addBackground(background);

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -154,6 +154,7 @@ LayoutBuilder.prototype.tryLayoutDocument = function (docStructure, fontProvider
 	var _this = this;
 	this.writer.context().tracker.startTracking('pageAdded', function () {
 		_this.addBackground(background);
+		_this.writer.context().backgroundLength.push(0);
 	});
 
 	this.addBackground(background);
@@ -182,7 +183,7 @@ LayoutBuilder.prototype.addBackground = function (background) {
 		pageBackground = this.docPreprocessor.preprocessDocument(pageBackground);
 		this.processNode(this.docMeasure.measureDocument(pageBackground));
 		this.writer.commitUnbreakableBlock(0, 0);
-		context.hasBackground = true;
+		context.backgroundLength[context.page]+=pageBackground.positions.length;
 	}
 };
 

--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -323,7 +323,7 @@ TableProcessor.prototype.endRow = function (rowIndex, writer, pageBreaks) {
 						h: y2 + this.bottomLineWidth - yf,
 						lineWidth: 0,
 						color: fillColor
-					}, false, true, writer.context().hasBackground ? 1 : 0);
+					}, false, true, writer.context().backgroundLength[writer.context().page]);
 				}
 			}
 		}

--- a/tests/integration/background.js
+++ b/tests/integration/background.js
@@ -72,4 +72,99 @@ describe('Integration test: background', function () {
 		assert.equal(fillColorRect.color, '#7d02c9');
 	});
 
+	/*
+	This should test any case in which function addPageItem is called with
+	defined index. This includes but might not be limited to:
+	-Vectors
+	-Qr
+	-Lists
+	-Tables
+	-Images
+	-Leafs
+	*/
+	it('background elements remain at the bottom of item list', function () {
+		var dd = {
+			background: function () {
+				return [
+					{
+						canvas: [
+							{
+								type: 'rect',
+								x: 0,
+								y: 0,
+								w: 50,
+								h: 50,
+								color: 'red'
+							},
+							{
+								type: 'rect',
+								x: 0,
+								y: 0,
+								w: 50,
+								h: 50,
+								color: 'green'
+							},
+							{
+								type: 'rect',
+								x: 0,
+								y: 0,
+								w: 50,
+								h: 50,
+								color: 'blue'
+							}
+						]
+					}
+				];
+			},
+			content: [
+				{
+					table: {
+						body: [
+							[
+								{
+									text: 'a',
+									fillColor: '#aaa'
+								},
+								{
+									text: 'b',
+									fillColor: '#bbb'
+								},
+								{
+									text: 'c',
+									fillColor: '#ccc'
+								}
+							]
+						]
+					}
+				},
+				{
+					qr: 'qr',
+					foreground: 'red',
+					background: 'yellow'
+				},
+				{
+					ul: [
+						'List 1',
+						'List 2',
+						'List 3'
+					]
+				},
+				{
+					image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+				},
+				{
+					text: 'Leaf'
+				}
+			]
+		};
+		var pages = testHelper.renderPages('A6', dd);
+		assert.equal(pages.length, 1);
+		var first = pages[0].items[0].item;
+		var second = pages[0].items[1].item;
+		var third = pages[0].items[2].item;
+		assert.equal(first.color, 'red');
+		assert.equal(second.color, 'green');
+		assert.equal(third.color, 'blue');
+	});
+
 });

--- a/tests/integration/background.js
+++ b/tests/integration/background.js
@@ -82,7 +82,7 @@ describe('Integration test: background', function () {
 	-Images
 	-Leafs
 	*/
-	it('background elements remain at the bottom of item list', function () {
+	it('background elements remain at the bottom of item list on every page', function () {
 		var dd = {
 			background: function () {
 				return [
@@ -153,18 +153,45 @@ describe('Integration test: background', function () {
 					image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
 				},
 				{
-					text: 'Leaf'
+					text: 'Leaf',
+					pageBreak: 'after'
+				},
+				{
+					table: {
+						body: [
+							[
+								{
+									text: 'a',
+									fillColor: '#aaa'
+								},
+								{
+									text: 'b',
+									fillColor: '#bbb'
+								},
+								{
+									text: 'c',
+									fillColor: '#ccc'
+								}
+							]
+						]
+					}
 				}
 			]
 		};
 		var pages = testHelper.renderPages('A6', dd);
-		assert.equal(pages.length, 1);
+		assert.equal(pages.length, 2);
 		var first = pages[0].items[0].item;
 		var second = pages[0].items[1].item;
 		var third = pages[0].items[2].item;
+		var first2 = pages[1].items[0].item;
+		var second2 = pages[1].items[1].item;
+		var third2 = pages[1].items[2].item;
 		assert.equal(first.color, 'red');
 		assert.equal(second.color, 'green');
 		assert.equal(third.color, 'blue');
+		assert.equal(first2.color, 'red');
+		assert.equal(second2.color, 'green');
+		assert.equal(third2.color, 'blue');
 	});
 
 });


### PR DESCRIPTION
There was a bug in #1201 which caused element indexing to be messed up on pages from 2 onward. This fixes it and extends test cause to catch this.