### PR TITLE
text field can be used along with pageReference

### DIFF
--- a/src/docPreprocessor.js
+++ b/src/docPreprocessor.js
@@ -149,7 +149,7 @@ DocPreprocessor.prototype.preprocessText = function (node) {
 		if (!this.nodeReferences[node.pageReference]) {
 			this.nodeReferences[node.pageReference] = {_nodeRef: {}, _pseudo: true};
 		}
-		node.text = '00000';
+		node.text = node.text ? node.text: '00000';
 		node._pageRef = this.nodeReferences[node.pageReference];
 	}
 


### PR DESCRIPTION
Solves issue number #1347.
If a text attribute is present along with the page Reference attribute, the content in the text field will also show up along with the header referenced by page Reference attribute. 