### PR TITLE
Add ability to preserve trailing white space

### DIFF
--- a/src/textTools.js
+++ b/src/textTools.js
@@ -301,13 +301,12 @@ function measure(fontProvider, textArray, styleContextStack) {
 		item.width = widthOfString(item.text, font, fontSize, characterSpacing, fontFeatures);
 		item.height = font.lineHeight(fontSize) * lineHeight;
 
-		var leadingSpaces = item.text.match(LEADING);
-
 		if (!item.leadingCut) {
 			item.leadingCut = 0;
 		}
 
-		if (leadingSpaces && !preserveLeadingSpaces) {
+		var leadingSpaces;
+		if (!preserveLeadingSpaces && (leadingSpaces = item.text.match(LEADING))) {
 			item.leadingCut += widthOfString(leadingSpaces[0], font, fontSize, characterSpacing, fontFeatures);
 		}
 

--- a/src/textTools.js
+++ b/src/textTools.js
@@ -295,6 +295,7 @@ function measure(fontProvider, textArray, styleContextStack) {
 		var linkToPage = getStyleProperty(item, styleContextStack, 'linkToPage', null);
 		var noWrap = getStyleProperty(item, styleContextStack, 'noWrap', null);
 		var preserveLeadingSpaces = getStyleProperty(item, styleContextStack, 'preserveLeadingSpaces', false);
+		var preserveTrailingSpaces = getStyleProperty(item, styleContextStack, 'preserveTrailingSpaces', false);
 
 		var font = fontProvider.provideFont(fontName, bold, italics);
 
@@ -310,8 +311,8 @@ function measure(fontProvider, textArray, styleContextStack) {
 			item.leadingCut += widthOfString(leadingSpaces[0], font, fontSize, characterSpacing, fontFeatures);
 		}
 
-		var trailingSpaces = item.text.match(TRAILING);
-		if (trailingSpaces) {
+		var trailingSpaces;
+		if (!preserveTrailingSpaces && (trailingSpaces = item.text.match(TRAILING))) {
 			item.trailingCut = widthOfString(trailingSpaces[0], font, fontSize, characterSpacing, fontFeatures);
 		} else {
 			item.trailingCut = 0;

--- a/tests/textTools.js
+++ b/tests/textTools.js
@@ -107,6 +107,10 @@ describe('TextTools', function () {
 		{text: '    This is a paragraph', preserveLeadingSpaces: true}
 	];
 
+	var textWithTrailingSpaces = [
+		{text: 'This is a paragraph    ', preserveTrailingSpaces: true}
+	];
+
 	var mixedTextArrayWithVariousTypes = [
 		{text: ''},
 		{text: null},
@@ -407,6 +411,11 @@ describe('TextTools', function () {
 
 		it('should preserve leading whitespaces when preserveLeadingSpaces is set', function () {
 			var inlines = textTools.buildInlines(textWithLeadingSpaces);
+			assert.equal(inlines.maxWidth, 23 * 12);
+		});
+
+		it('should preserve trailing whitespaces when preserveTrailingSpaces is set', function () {
+			var inlines = textTools.buildInlines(textWithTrailingSpaces);
 			assert.equal(inlines.maxWidth, 23 * 12);
 		});
 	});


### PR DESCRIPTION
Also, cleaned up order of options in `if` check to check the cheapest expression first.