### PR TITLE
Export fs (virtual file system) in main client side module

### DIFF
--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var PdfPrinter = require('../printer');
 var isFunction = require('../helpers').isFunction;
 var FileSaver = require('file-saver');
@@ -36,7 +37,7 @@ Document.prototype._createDoc = function (options, callback) {
 	}
 
 	var printer = new PdfPrinter(this.fonts);
-	require('fs').bindFS(this.vfs); // bind virtual file system to file system
+	fs.bindFS(this.vfs); // bind virtual file system to file system
 
 	var doc = printer.createPdfKitDocument(this.docDefinition, options);
 	var chunks = [];
@@ -187,5 +188,6 @@ module.exports = {
 			throw 'Your browser does not provide the level of support needed';
 		}
 		return new Document(docDefinition, global.pdfMake.tableLayouts, global.pdfMake.fonts, global.pdfMake.vfs);
-	}
+	},
+	fs: fs
 };


### PR DESCRIPTION
Currently the data registered in virtual file system through pdfMake.vfs is [converted to a Buffer instance](https://github.com/bpampuch/pdfmake/blob/master/src/browser-extensions/virtual-fs.js#L13). This fine in most situations but does not work in cases where the raw content is expected like [AFM font data](https://github.com/foliojs/pdfkit/blob/master/lib/font/standard.coffee#L50-L63)

By exporting fs is possible to store the AFM font data using [fs.writeFileSync](https://github.com/bpampuch/pdfmake/blob/master/src/browser-extensions/virtual-fs.js#L24)