### PR TITLE
Allow passing tableLayouts, fonts and vfs to createPdf

### DIFF
--- a/src/browser-extensions/pdfMake.js
+++ b/src/browser-extensions/pdfMake.js
@@ -182,10 +182,15 @@ Document.prototype.getBuffer = function (cb, options) {
 };
 
 module.exports = {
-	createPdf: function (docDefinition) {
+	createPdf: function (docDefinition, tableLayouts, fonts, vfs) {
 		if (!canCreatePdf()) {
 			throw 'Your browser does not provide the level of support needed';
 		}
-		return new Document(docDefinition, global.pdfMake.tableLayouts, global.pdfMake.fonts, global.pdfMake.vfs);
+		return new Document(
+			docDefinition,
+			tableLayouts || global.pdfMake.tableLayouts,
+			fonts || global.pdfMake.fonts,
+			vfs || global.pdfMake.vfs
+		);
 	}
 };


### PR DESCRIPTION
Specifying `tableLayouts`, `fonts` and `vfs` via the global `pdfMake` variable can be problematic in some cases, for example with complex bundlers, build systems, etc.

It would be nice if these values could all be passed together to the `createPdf` function.
This PR allows that, but still allows using the global as well.

Let me know if any further tweaks, documentation updates, etc would be needed.