### PR TITLE
change file-saver to real dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "file-saver": "^2.0.0",
     "iconv-lite": "^0.4.24",
     "linebreak": "^0.3.0",
     "pdfkit": "^0.8.3"
@@ -15,7 +16,6 @@
     "brfs": "^2.0.1",
     "expose-loader": "^0.7.5",
     "fancy-log": "^1.3.2",
-    "file-saver": "^2.0.0",
     "gulp": "^4.0.0",
     "gulp-each": "^0.5.0",
     "gulp-eslint": "^5.0.0",


### PR DESCRIPTION
necessary when pdfmake is a dependency and compiled by a different wepack config