### PR TITLE
fix(lib): Fix phantom borders on some PDF renderers

### DIFF
--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -3,6 +3,8 @@
 var ColumnCalculator = require('./columnCalculator');
 var isFunction = require('./helpers').isFunction;
 
+var TABLE_FILL_CORRECTION = 0.5;
+
 function TableProcessor(tableNode) {
 	this.tableNode = tableNode;
 }
@@ -344,10 +346,10 @@ TableProcessor.prototype.endRow = function (rowIndex, writer, pageBreaks) {
 					var y2f = y2 + (this.bottomLineWidth / 2);
 					writer.addVector({
 						type: 'rect',
-						x: x1f,
-						y: y1f,
-						w: x2f - x1f,
-						h: y2f - y1f,
+						x: x1f - TABLE_FILL_CORRECTION,
+						y: y1f - TABLE_FILL_CORRECTION,
+						w: x2f - x1f + TABLE_FILL_CORRECTION,
+						h: y2f - y1f + TABLE_FILL_CORRECTION,
 						lineWidth: 0,
 						color: fillColor
 					}, false, true, writer.context().backgroundLength[writer.context().page]);


### PR DESCRIPTION
Hi,

I found this issue which happens to me on a project: https://github.com/bpampuch/pdfmake/issues/1088
I've seen rendered PDF works perfectly on some renderers (like Chrome renderer) but not on others (in my case, Mozilla jsPDF renderer).

After some experimentations, I found that adding a small number of pixels in the rect generated for the table cell background fix the problem. I tested with very small values (< 0.1), but it works only with a 0.5 value.

I interpret this bug as an error of rendering on float values by the renderer (which perhaps do some conversion to integers). Adding 0.5 stops these bugs. In fact, I also checked the generated rect sizes, but there's no problem in the lib. That's why I consider it comes from renderers.

Here are some examples before and after the fix:

### BEFORE
![beforehorizontal](https://user-images.githubusercontent.com/1839713/52419085-aa0c6480-2aef-11e9-8dc0-b89c14c0c2f5.png)
![beforevertical](https://user-images.githubusercontent.com/1839713/52419088-aa0c6480-2aef-11e9-9c09-bcf10f724994.png)

### AFTER
![afterhorizontal](https://user-images.githubusercontent.com/1839713/52419083-a973ce00-2aef-11e9-9613-f777855f1270.png)
![aftervertical](https://user-images.githubusercontent.com/1839713/52419084-a973ce00-2aef-11e9-96ad-a126f86c1915.png)

I know this is a *hacky fix*, but I don't find any better solutions for that.