### PR TITLE
added capability to set table border color by cell

### DIFF
--- a/examples/tables.js
+++ b/examples/tables.js
@@ -532,7 +532,95 @@ var docDefinition = {
 					]
 				]
 			}
-		}
+		},
+		{text: 'BorderColor per Cell with Column/row spans', pageBreak: 'before', style: 'subheader'},
+		'Each cell-element can set the borderColor (the cell above or left of the current cell has priority',
+		{
+			style: 'tableExample',
+			color: '#444',
+			table: {
+				widths: [200, 'auto', 'auto'],
+				headerRows: 2,
+				// keepWithHeaderRows: 1,
+				body: [
+					[
+						{
+							text: 'Header with Colspan = 3',
+							style: 'tableHeader',
+							colSpan: 3,
+							borderColor: ['#ff00ff', '#00ffff', '#ff00ff', '#00ffff'],
+							alignment: 'center',
+						},
+						{},
+						{},
+					],
+					[
+						{
+							text: 'Header 1',
+							style: 'tableHeader',
+							alignment: 'center',
+						},
+						{
+							text: 'Header 2',
+							style: 'tableHeader',
+							alignment: 'center',
+						},
+						{
+							text: 'Header 3',
+							style: 'tableHeader',
+							alignment: 'center',
+						},
+					],
+					[
+						'Sample value 1',
+						'Sample value 2',
+						'Sample value 3',
+					],
+					[
+						{
+							rowSpan: 3,
+							borderColor: ['#ff00ff', '#00ffff', '#ff00ff', '#00ffff'],
+							text: 'rowSpan set to 3\nLorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor',
+						},
+						'Sample value 2',
+						{
+							text: 'Sample value 3',
+							borderColor: ['#ff00ff', '#00ffff', '#ff00ff', '#00ffff'],
+						},
+					],
+					[
+						'',
+						'Sample value 2',
+						'Sample value 3',
+					],
+					[
+						'Sample value 1',
+						'Sample value 2',
+						'Sample value 3',
+					],
+					[
+						'Sample value 1',
+						{
+							colSpan: 2,
+							rowSpan: 2,
+							borderColor: ['#ff00ff', '#00ffff', '#ff00ff', '#00ffff'],
+							text: 'Both:\nrowSpan and colSpan\ncan be defined at the same time',
+						},
+						'',
+					],
+					[
+						'Sample value 1',
+						{
+							text: 'a', borderColor: ['#ff00ff', '#00ffff', '#ff00ff', '#00ffff'],
+						},
+						{
+							text: '',
+							borderColor: ['#ff00ff', '#00ffff', '#ff00ff', '#00ffff'],
+						},
+					],
+				],
+			},
+		},
 	],
 	styles: {
 		header: {

--- a/src/tableProcessor.js
+++ b/src/tableProcessor.js
@@ -161,22 +161,29 @@ TableProcessor.prototype.drawHorizontalLine = function (lineIndex, writer, overr
 		for (var i = 0, l = this.rowSpanData.length; i < l; i++) {
 			var data = this.rowSpanData[i];
 			var shouldDrawLine = !data.rowSpan;
+			var borderColor;
 
 			// draw only if the current cell requires a top border or the cell in the
 			// row above requires a bottom border
 			if (shouldDrawLine && i < l - 1) {
 				var topBorder = false, bottomBorder = false;
 
-				// the current cell
-				if (lineIndex < body.length) {
-					var cell = body[lineIndex][i];
-					topBorder = cell.border ? cell.border[1] : this.layout.defaultBorder;
-				}
-
 				// the cell in the row above
 				if (lineIndex > 0) {
 					var cellAbove = body[lineIndex - 1][i];
 					bottomBorder = cellAbove.border ? cellAbove.border[3] : this.layout.defaultBorder;
+					if (cellAbove.borderColor) {
+						borderColor = cellAbove.borderColor[3];
+					}
+				}
+
+				// the current cell
+				if (lineIndex < body.length) {
+					var cell = body[lineIndex][i];
+					topBorder = cell.border ? cell.border[1] : this.layout.defaultBorder;
+					if (borderColor == null && cell.borderColor) {
+						borderColor = cell.borderColor[1];
+					}
 				}
 
 				shouldDrawLine = topBorder || bottomBorder;
@@ -192,7 +199,11 @@ TableProcessor.prototype.drawHorizontalLine = function (lineIndex, writer, overr
 
 			var y = (overrideY || 0) + offset;
 
-			if (!shouldDrawLine || i === l - 1) {
+			if (borderColor == null) {
+				borderColor = isFunction(this.layout.hLineColor) ? this.layout.hLineColor(lineIndex, this.tableNode, i) : this.layout.hLineColor;
+			}
+
+			if (shouldDrawLine) {
 				if (currentLine && currentLine.width) {
 					writer.addVector({
 						type: 'line',
@@ -202,9 +213,10 @@ TableProcessor.prototype.drawHorizontalLine = function (lineIndex, writer, overr
 						y2: y,
 						lineWidth: lineWidth,
 						dash: dash,
-						lineColor: isFunction(this.layout.hLineColor) ? this.layout.hLineColor(lineIndex, this.tableNode) : this.layout.hLineColor
+						lineColor: borderColor
 					}, false, overrideY);
 					currentLine = null;
+					borderColor = null;
 				}
 			}
 		}
@@ -213,15 +225,38 @@ TableProcessor.prototype.drawHorizontalLine = function (lineIndex, writer, overr
 	}
 };
 
-TableProcessor.prototype.drawVerticalLine = function (x, y0, y1, vLineIndex, writer) {
-	var width = this.layout.vLineWidth(vLineIndex, this.tableNode);
+TableProcessor.prototype.drawVerticalLine = function (x, y0, y1, vLineColIndex, writer, vLineRowIndex) {
+	var width = this.layout.vLineWidth(vLineColIndex, this.tableNode);
 	if (width === 0) {
 		return;
 	}
-	var style = this.layout.vLineStyle(vLineIndex, this.tableNode);
+	var style = this.layout.vLineStyle(vLineColIndex, this.tableNode);
 	var dash;
 	if (style && style.dash) {
 		dash = style.dash;
+	}
+
+	var body = this.tableNode.table.body;
+	var borderColor;
+
+	// the cell in the col before
+	if (vLineColIndex > 0) {
+		var cellBefore = body[vLineRowIndex][vLineColIndex - 1];
+		if (cellBefore && cellBefore.borderColor) {
+			borderColor = cellBefore.borderColor[2];
+		}
+	}
+
+	// the current cell
+	if (borderColor == null && vLineColIndex < body.length) {
+		var cell = body[vLineRowIndex][vLineColIndex];
+		if (cell && cell.borderColor) {
+			borderColor = cell.borderColor[0];
+		}
+
+	}
+	if(borderColor == null) {
+		borderColor = isFunction(this.layout.vLineColor) ? this.layout.vLineColor(vLineColIndex, this.tableNode, vLineRowIndex) : this.layout.vLineColor;
 	}
 	writer.addVector({
 		type: 'line',
@@ -231,8 +266,9 @@ TableProcessor.prototype.drawVerticalLine = function (x, y0, y1, vLineIndex, wri
 		y2: y1,
 		lineWidth: width,
 		dash: dash,
-		lineColor: isFunction(this.layout.vLineColor) ? this.layout.vLineColor(vLineIndex, this.tableNode) : this.layout.vLineColor
+		lineColor: borderColor
 	}, false, true);
+	borderColor = null;
 };
 
 TableProcessor.prototype.endTable = function (writer) {
@@ -319,7 +355,7 @@ TableProcessor.prototype.endRow = function (rowIndex, writer, pageBreaks) {
 			}
 
 			if (leftCellBorder) {
-				this.drawVerticalLine(xs[i].x, y1 - hzLineOffset, y2 + this.bottomLineWidth, xs[i].index, writer);
+				this.drawVerticalLine(xs[i].x, y1 - hzLineOffset, y2 + this.bottomLineWidth, xs[i].index, writer, rowIndex);
 			}
 
 			if (i < l - 1) {


### PR DESCRIPTION
Hello there,

I added a feature to set the table border color per cell. The h-/vLineColor callback is now returning the current row, node and col.
I also implemented a way to set the border color like the borders property. So you can add borderColor to the cell like
```
borderColor = ["#ff00ff", "#00ff00", "#ff00ff", "#00ff00"]
```

The current logic will prefer the border colors of the above or the cell left of the current cell. So if the left cell set the right border to blue, and the current to yellow, the border will be blue. As fallback, the current callback function will be used. To use the color of the current cell, you can set the right border of the cell before to null.