### PR TITLE
fix loading standard fonts in browser

### DIFF
--- a/src/browser-extensions/virtual-fs.js
+++ b/src/browser-extensions/virtual-fs.js
@@ -5,10 +5,14 @@ function VirtualFileSystem() {
 	this.dataSystem = {};
 }
 
-VirtualFileSystem.prototype.readFileSync = function (filename) {
+VirtualFileSystem.prototype.readFileSync = function (filename, option) {
 	filename = fixFilename(filename);
 
-	var dataContent = this.dataSystem[filename];
+  var dataContent = this.dataSystem[filename];
+  if (typeof dataContent === 'string' && option === 'utf8') {
+    return dataContent;
+	}
+	
 	if (dataContent) {
 		return new Buffer(dataContent, typeof dataContent === 'string' ? 'base64' : undefined);
 	}


### PR DESCRIPTION
Fix loading standard fonts in browser

## Problem
Standard Fonts ('afm') do not load in browser.

## Description
After some research I figured out that the main problem is that the virtual file system adapter for the browser does not implement all required functionalities.

`pdfmake` load the standard font by following code:
```js
   STANDARD_FONTS = {
      "Courier": function() {
        return fs.readFileSync(__dirname + "/../font/data/Courier.afm", 'utf8');
      },
```
`fs.readFileSync("path")` returns a buffer while `fs.readFileSync("path", 'utf8')` returns a string.
But the browser adapter only implements `fs.readFileSync("path")` so it returns a buffer and the `AFMFont.parse` fails.


## Solution
Extend readFileSync(); by missing `option` argument.

## Reference
https://github.com/blikblum/pdfmake-utils/issues/1

