### PR TITLE
Fix relative positioning

### DIFF
--- a/examples/relative.js
+++ b/examples/relative.js
@@ -31,7 +31,36 @@ var documentDefinition = {content: [
 		{columns: [
 				{width: '50%', text: 'horizontal position is not known either'},
 				{width: '50%', stack: chart}
-			]}
+			]},
+		{text: 'We can position relative with center and right alignment', margin: [0, 50, 0, 50]},
+		{
+			table: {
+				widths: [100, 100, 100],
+				body: [
+					['Column with a lot of text. Column with a lot of text. Column with a lot of text. Column with a lot of text.',
+					{
+						text: 'I\'m aligned center',
+						style: {
+							alignment: 'center',
+						},
+						relativePosition: {
+							x: 0,
+							y: 25,
+						}
+					},
+						{
+							text: 'I\'m aligned right',
+							style: {
+								alignment: 'right',
+							},
+							relativePosition: {
+								x: 0,
+								y: 25,
+							}
+						}]
+				]
+			}
+		},
 	]};
 
 var pdfDoc = printer.createPdfKitDocument(documentDefinition);

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -159,6 +159,15 @@ DocumentContext.prototype.moveTo = function (x, y) {
 	}
 };
 
+DocumentContext.prototype.moveToRelative = function (x, y) {
+	if (x !== undefined && x !== null) {
+		this.x = this.x + x;
+	}
+	if (y !== undefined && y !== null) {
+		this.y = this.y + y;
+	}
+};
+
 DocumentContext.prototype.beginDetachedBlock = function () {
 	this.snapshots.push({
 		x: this.x,

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -358,7 +358,7 @@ LayoutBuilder.prototype.processNode = function (node) {
 		var relPosition = node.relativePosition;
 		if (relPosition) {
 			self.writer.context().beginDetachedBlock();
-			self.writer.context().moveTo((relPosition.x || 0) + self.writer.context().x, (relPosition.y || 0) + self.writer.context().y);
+			self.writer.context().moveToRelative(relPosition.x || 0, relPosition.y || 0);
 		}
 
 		if (node.stack) {

--- a/tests/documentContext.js
+++ b/tests/documentContext.js
@@ -246,6 +246,17 @@ describe('DocumentContext', function () {
 
 	});
 
+	describe('moveToRelative', function () {
+		it('should change coordinates', function () {
+			pc.x = 100;
+			pc.y = 200;
+			pc.moveToRelative(50, 100);
+
+			assert.equal(pc.x, 150);
+			assert.equal(pc.y, 300);
+		});
+	});
+
 	describe('addPage', function () {
 
 		var pageSize;

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1388,6 +1388,60 @@ describe('LayoutBuilder', function () {
 			assert.equal(pages.length, 1);
 		});
 
+		it('should use the relativePosition attribute to position in relativePosition coordinates', function () {
+			var desc = [
+					{
+						text: 'text 1',
+						relativePosition: { x: 123, y: 200 }
+					},
+					{
+						text: 'text 2',
+						relativePosition: { x: 0, y: 0 }
+					}
+				]
+			;
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages[0].items[0].item.x, 163);
+			assert.equal(pages[0].items[0].item.y, 240);
+			assert.equal(pages[0].items[1].item.x, 40);
+			assert.equal(pages[0].items[1].item.y, 40);
+		});
+
+		it('should use the relativePosition attribute to position in relativePosition coordinates in a table cell', function () {
+			var desc = [
+				{
+					table: {
+						widths: [200, 200],
+						body: [
+							[
+								{
+									text: 'text 1',
+									style: {
+										alignment: 'center',
+									},
+									relativePosition: { x: 10, y: 200 },
+								},
+								{
+									text: 'text 2',
+									relativePosition: { x: 0, y: 0 }
+								}
+							],
+						],
+					},
+					layout: emptyTableLayout,
+				},
+			];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider, {});
+
+			assert.equal(pages[0].items[0].item.x, 114);
+			assert.equal(pages[0].items[0].item.y, 240);
+			assert.equal(pages[0].items[1].item.x, 240);
+			assert.equal(pages[0].items[1].item.y, 40);
+		});
+
 		it('should not break nodes across multiple pages when unbreakable attribute is passed', function () {
 			var desc = [
 				{


### PR DESCRIPTION
I tried to position centered items relatively in table cells and the layout messed up.

I found out that the root cause was that DocumentContext updated availableWidth property based on page size, not on the width of the cell. If you are using relative positioning in a full width context it's working fine, but in a table cell it's buggy.

I've added an example to relative.js too, you can try it with and without my fix.

Should you have any suggestion don't hesitate to ask, I will make the necessary changes quickly, so that you can merge it as soon as possible.