### PR TITLE
Dynamic page margins

### DIFF
--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -159,11 +159,11 @@ DocumentContext.prototype.pageSnapshot = function () {
 DocumentContext.prototype.moveTo = function (x, y) {
 	if (x !== undefined && x !== null) {
 		this.x = x;
-		this.availableWidth = this.getCurrentPage().pageSize.width - this.x - this.pageMargins.right;
+		this.availableWidth = this.getCurrentPage().pageSize.width - this.x - this.getCurrentPage().pageMargins.right;
 	}
 	if (y !== undefined && y !== null) {
 		this.y = y;
-		this.availableHeight = this.getCurrentPage().pageSize.height - this.y - this.pageMargins.bottom;
+		this.availableHeight = this.getCurrentPage().pageSize.height - this.y - this.getCurrentPage().pageMargins.bottom;
 	}
 };
 

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -10,12 +10,7 @@ var isString = require('./helpers').isString;
 function DocumentContext(pageSize, pageMargins) {
 	this.pages = [];
 
-	this.pageMargins = pageMargins;
-
-	if (typeof pageMargins === 'function') {
-		this.pageMarginsFn = pageMargins;
-		this.pageMargins = pageMargins(1)
-	}
+	this.pageMargins = typeof pageMargins === 'function' ? pageMargins : function () {return pageMargins};
 
 	this.x = pageMargins.left;
 	this.availableWidth = pageSize.width - pageMargins.left - pageMargins.right;
@@ -267,10 +262,11 @@ DocumentContext.prototype.moveToNextPage = function (pageOrientation) {
 };
 
 DocumentContext.prototype.addPage = function (pageSize) {
-	var page = {items: [], pageSize: pageSize};
-
-	if (this.pageMarginsFn) page.pageMargins = this.pageMarginsFn(this.pages.length);
-
+	var page = {
+		items: [],
+		pageSize: pageSize,
+		pageMargins: this.pageMargins(this.pages.length)
+	};
 	this.pages.push(page);
 	this.backgroundLength.push(0);
 	this.page = this.pages.length - 1;
@@ -296,7 +292,7 @@ DocumentContext.prototype.getCurrentPosition = function () {
 	var innerWidth = pageSize.width - this.getCurrentPage().pageMargins.left - this.getCurrentPage().pageMargins.right;
 
 	return {
-        pageMargins: this.getCurrentPage().pageMargins,
+		pageMargins: this.getCurrentPage().pageMargins,
 		pageNumber: this.page + 1,
 		pageOrientation: pageSize.orientation,
 		pageInnerHeight: innerHeight,

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -265,7 +265,7 @@ DocumentContext.prototype.addPage = function (pageSize) {
 	var page = {
 		items: [],
 		pageSize: pageSize,
-		pageMargins: this.pageMargins(this.pages.length)
+		pageMargins: this.pageMargins(this.pages.length + 1)
 	};
 	this.pages.push(page);
 	this.backgroundLength.push(0);

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -12,12 +12,12 @@ function DocumentContext(pageSize, pageMargins) {
 
 	this.pageMargins = pageMargins;
 
-    if (typeof pageMargins === 'function') {
-        this.pageMarginsFn = pageMargins;
-        this.pageMargins = pageMargins(1)
-    }
+	if (typeof pageMargins === 'function') {
+		this.pageMarginsFn = pageMargins;
+		this.pageMargins = pageMargins(1)
+	}
 
-    this.x = pageMargins.left;
+	this.x = pageMargins.left;
 	this.availableWidth = pageSize.width - pageMargins.left - pageMargins.right;
 	this.availableHeight = 0;
 	this.page = -1;
@@ -269,7 +269,7 @@ DocumentContext.prototype.moveToNextPage = function (pageOrientation) {
 DocumentContext.prototype.addPage = function (pageSize) {
 	var page = {items: [], pageSize: pageSize};
 
-    if (this.pageMarginsFn) page.pageMargins = this.pageMarginsFn(this.pages.length);
+	if (this.pageMarginsFn) page.pageMargins = this.pageMarginsFn(this.pages.length);
 
 	this.pages.push(page);
 	this.backgroundLength.push(0);

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -12,7 +12,12 @@ function DocumentContext(pageSize, pageMargins) {
 
 	this.pageMargins = pageMargins;
 
-	this.x = pageMargins.left;
+    if (typeof pageMargins === 'function') {
+        this.pageMarginsFn = pageMargins;
+        this.pageMargins = pageMargins(1)
+    }
+
+    this.x = pageMargins.left;
 	this.availableWidth = pageSize.width - pageMargins.left - pageMargins.right;
 	this.availableHeight = 0;
 	this.page = -1;
@@ -135,9 +140,17 @@ DocumentContext.prototype.moveDown = function (offset) {
 };
 
 DocumentContext.prototype.initializePage = function () {
-	this.y = this.pageMargins.top;
-	this.availableHeight = this.getCurrentPage().pageSize.height - this.pageMargins.top - this.pageMargins.bottom;
-	this.pageSnapshot().availableWidth = this.getCurrentPage().pageSize.width - this.pageMargins.left - this.pageMargins.right;
+    this.y = this.getCurrentPage().pageMargins.top;
+
+    this.availableHeight =
+        this.getCurrentPage().pageSize.height -
+        this.getCurrentPage().pageMargins.top -
+        this.getCurrentPage().pageMargins.bottom;
+
+    this.pageSnapshot().availableWidth =
+        this.getCurrentPage().pageSize.width -
+        this.getCurrentPage().pageMargins.left -
+        this.getCurrentPage().pageMargins.right;
 };
 
 DocumentContext.prototype.pageSnapshot = function () {
@@ -253,13 +266,16 @@ DocumentContext.prototype.moveToNextPage = function (pageOrientation) {
 	};
 };
 
-
 DocumentContext.prototype.addPage = function (pageSize) {
 	var page = {items: [], pageSize: pageSize};
+
+    if (this.pageMarginsFn) page.pageMargins = this.pageMarginsFn(this.pages.length);
+
 	this.pages.push(page);
 	this.backgroundLength.push(0);
 	this.page = this.pages.length - 1;
-	this.initializePage();
+
+    this.initializePage();
 
 	this.tracker.emit('pageAdded');
 
@@ -276,18 +292,19 @@ DocumentContext.prototype.getCurrentPage = function () {
 
 DocumentContext.prototype.getCurrentPosition = function () {
 	var pageSize = this.getCurrentPage().pageSize;
-	var innerHeight = pageSize.height - this.pageMargins.top - this.pageMargins.bottom;
-	var innerWidth = pageSize.width - this.pageMargins.left - this.pageMargins.right;
+	var innerHeight = pageSize.height - this.getCurrentPage().pageMargins.top - this.getCurrentPage().pageMargins.bottom;
+	var innerWidth = pageSize.width - this.getCurrentPage().pageMargins.left - this.getCurrentPage().pageMargins.right;
 
 	return {
+        pageMargins: this.getCurrentPage().pageMargins,
 		pageNumber: this.page + 1,
 		pageOrientation: pageSize.orientation,
 		pageInnerHeight: innerHeight,
 		pageInnerWidth: innerWidth,
 		left: this.x,
 		top: this.y,
-		verticalRatio: ((this.y - this.pageMargins.top) / innerHeight),
-		horizontalRatio: ((this.x - this.pageMargins.left) / innerWidth)
+		verticalRatio: ((this.y - this.getCurrentPage().pageMargins.top) / innerHeight),
+		horizontalRatio: ((this.x - this.getCurrentPage().pageMargins.left) / innerWidth)
 	};
 };
 

--- a/src/documentContext.js
+++ b/src/documentContext.js
@@ -10,10 +10,10 @@ var isString = require('./helpers').isString;
 function DocumentContext(pageSize, pageMargins) {
 	this.pages = [];
 
-	this.pageMargins = typeof pageMargins === 'function' ? pageMargins : function () {return pageMargins};
+	this.pageMargins = pageMargins;
 
-	this.x = pageMargins.left;
-	this.availableWidth = pageSize.width - pageMargins.left - pageMargins.right;
+	this.x = pageMargins(1).left;
+	this.availableWidth = pageSize.width - pageMargins(1).left - pageMargins(1).right;
 	this.availableHeight = 0;
 	this.page = -1;
 
@@ -271,7 +271,7 @@ DocumentContext.prototype.addPage = function (pageSize) {
 	this.backgroundLength.push(0);
 	this.page = this.pages.length - 1;
 
-    this.initializePage();
+	this.initializePage();
 
 	this.tracker.emit('pageAdded');
 

--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -298,7 +298,7 @@ ElementWriter.prototype.pushContext = function (contextOrWidth, height) {
 	}
 
 	if (isNumber(contextOrWidth)) {
-		contextOrWidth = new DocumentContext({width: contextOrWidth, height: height}, {left: 0, right: 0, top: 0, bottom: 0});
+		contextOrWidth = new DocumentContext({width: contextOrWidth, height: height}, function () {return {left: 0, right: 0, top: 0, bottom: 0}});
 	}
 
 	this.contextStack.push(this.context);

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -202,7 +202,7 @@ LayoutBuilder.prototype.addDynamicRepeatable = function (nodeGetter, sizeFunctio
 		var node = nodeGetter(pageIndex + 1, l, this.writer.context().pages[pageIndex].pageSize);
 
 		if (node) {
-			var sizes = sizeFunction(this.writer.context().getCurrentPage().pageSize, this.getCurrentPage().pageMargins);
+			var sizes = sizeFunction(this.writer.context().getCurrentPage().pageSize, this.writer.context().getCurrentPage().pageMargins);
 			this.writer.beginUnbreakableBlock(sizes.width, sizes.height);
 			node = this.docPreprocessor.preprocessDocument(node);
 			this.processNode(this.docMeasure.measureDocument(node));

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -202,7 +202,7 @@ LayoutBuilder.prototype.addDynamicRepeatable = function (nodeGetter, sizeFunctio
 		var node = nodeGetter(pageIndex + 1, l, this.writer.context().pages[pageIndex].pageSize);
 
 		if (node) {
-			var sizes = sizeFunction(this.writer.context().getCurrentPage().pageSize, this.pageMargins);
+			var sizes = sizeFunction(this.writer.context().getCurrentPage().pageSize, this.getCurrentPage().pageMargins);
 			this.writer.beginUnbreakableBlock(sizes.width, sizes.height);
 			node = this.docPreprocessor.preprocessDocument(node);
 			this.processNode(this.docMeasure.measureDocument(node));

--- a/src/printer.js
+++ b/src/printer.js
@@ -232,7 +232,8 @@ function fixPageSize(pageSize, pageOrientation) {
 }
 
 function pageMarginsFn(margin, def) {
-	if(!isFunction(margin)) margin = function () {
+	var marginFn = margin;
+	if(!isFunction(margin)) marginFn = function () {
 		return margin;
 	};
 	

--- a/src/printer.js
+++ b/src/printer.js
@@ -109,7 +109,7 @@ PdfPrinter.prototype.createPdfKitDocument = function (docDefinition, options) {
 
 	this.fontProvider = new FontProvider(this.fontDescriptors, this.pdfKitDoc);
 
-	var builder = new LayoutBuilder(pageSize, fixPageMargins(docDefinition.pageMargins || 40), new ImageMeasure(this.pdfKitDoc, docDefinition.images));
+	var builder = new LayoutBuilder(pageSize, pageMarginsFn(docDefinition.pageMargins, 40), new ImageMeasure(this.pdfKitDoc, docDefinition.images));
 
 	registerDefaultTableLayouts(builder);
 	if (options.tableLayouts) {
@@ -231,13 +231,13 @@ function fixPageSize(pageSize, pageOrientation) {
 	return size;
 }
 
-function pageMarginsFn(margin) {
+function pageMarginsFn(margin, def) {
 	if(!isFunction(margin)) margin = function () {
 		return margin;
 	};
 	
 	return function (currentPage) {
-		return fixPageMargins(margin(currentPage))
+		return fixPageMargins(margin(currentPage)) || def;
 	}
 }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -238,7 +238,7 @@ function pageMarginsFn(margin, def) {
 	};
 	
 	return function (currentPage) {
-		return fixPageMargins(margin(currentPage) ||  def);
+		return fixPageMargins(marginFn(currentPage) ||  def);
 	}
 }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -237,7 +237,7 @@ function pageMarginsFn(margin, def) {
 	};
 	
 	return function (currentPage) {
-		return fixPageMargins(margin(currentPage)) || def;
+		return fixPageMargins(margin(currentPage) ||  def);
 	}
 }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -231,6 +231,16 @@ function fixPageSize(pageSize, pageOrientation) {
 	return size;
 }
 
+function pageMarginsFn(margin) {
+	if(!isFunction(margin)) margin = function () {
+		return margin;
+	};
+	
+	return function (currentPage) {
+		return fixPageMargins(margin(currentPage))
+	}
+}
+
 function fixPageMargins(margin) {
 	if (!margin) {
 		return null;


### PR DESCRIPTION
Makes document definition pageMargins dynamic (based on current page):
```
var docDefinition = {
  // [left, top, right, bottom] or [horizontal, vertical] or just a number for equal margins
  // E.g. make top margin on first page larger for logo that's already on the paper
  pageMargins: currentPage =>  [ 40, currentPage === 1 ? 160 : 60, 40, 60 ],
};
```

Non dynamic page margins are still supported:
```
var docDefinition = {
  // [left, top, right, bottom] or [horizontal, vertical] or just a number for equal margins
  pageMargins: [ 40, 60, 40, 60 ],
};
```

Changes have been based on comments from [Issue 368](https://github.com/bpampuch/pdfmake/issues/368) with some additonal changes:
- function return format is the same as non function format
- use fixPageMargins to validate all return values from pageMargins function