### PR TITLE
Fix short watermark positions - Closes #1764

### DIFF
--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -293,10 +293,11 @@ LayoutBuilder.prototype.addWatermark = function (watermark, fontProvider, defaul
 				fontSize: c
 			});
 			size = textTools.sizeOfString(watermark.text, styleContextStack);
-			if (size.width > targetWidth) {
+			const adjustedTargetWidth = targetWidth - (size.width * 0.5);
+			if (size.width > adjustedTargetWidth) {
 				b = c;
 				c = (a + b) / 2;
-			} else if (size.width < targetWidth) {
+			} else if (size.width < adjustedTargetWidth) {
 				a = c;
 				c = (a + b) / 2;
 			}

--- a/src/printer.js
+++ b/src/printer.js
@@ -496,7 +496,7 @@ function renderWatermark(page, pdfKitDoc) {
 	pdfKitDoc.rotate(angle, { origin: [pdfKitDoc.page.width / 2, pdfKitDoc.page.height / 2] });
 
 	var x = pdfKitDoc.page.width / 2 - watermark.size.size.width / 2;
-	var y = pdfKitDoc.page.height / 2 - watermark.size.size.height / 4;
+	var y = pdfKitDoc.page.height / 2 - watermark.size.size.height / 3;
 
 	pdfKitDoc._font = watermark.font;
 	pdfKitDoc.fontSize(watermark.size.fontSize);


### PR DESCRIPTION
While calculating the exact size and position for the watermark is theoretically just simple geometry, in practice it is quite fiddly. 
This PR contains changes that pragmatically approximate the desired positions. Three examples attached.

![long_watermark](https://user-images.githubusercontent.com/467510/61442844-43ae2c80-a940-11e9-8afc-1e2649361fd9.png)
![medium_watermark](https://user-images.githubusercontent.com/467510/61442845-43ae2c80-a940-11e9-87e9-4536c7066137.png)
![short_watermark](https://user-images.githubusercontent.com/467510/61442846-43ae2c80-a940-11e9-8740-686dd22982a0.png)
