### PR TITLE
Colors with opacity at zero to be fully transparent

### DIFF
--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -19,6 +19,7 @@ var getNodeId = require('./helpers').getNodeId;
 var isFunction = require('./helpers').isFunction;
 var TextTools = require('./textTools');
 var StyleContextStack = require('./styleContextStack');
+var isNumber = require('./helpers').isNumber;
 
 function addAll(target, otherArray) {
 	otherArray.forEach(function (item) {
@@ -258,7 +259,7 @@ LayoutBuilder.prototype.addWatermark = function (watermark, fontProvider, defaul
 	watermark.font = watermark.font || defaultStyle.font || 'Roboto';
 	watermark.fontSize = watermark.fontSize || 'auto';
 	watermark.color = watermark.color || 'black';
-	watermark.opacity = watermark.opacity || 0.6;
+	watermark.opacity = isNumber(watermark.opacity) ? watermark.opacity : 0.6;
 	watermark.bold = watermark.bold || false;
 	watermark.italics = watermark.italics || false;
 	watermark.angle = !isUndefined(watermark.angle) && !isNull(watermark.angle) ? watermark.angle : null;

--- a/src/printer.js
+++ b/src/printer.js
@@ -475,7 +475,8 @@ function renderLine(line, x, y, pdfKitDoc) {
 			options.features = inline.fontFeatures;
 		}
 
-		pdfKitDoc.opacity(inline.opacity || 1);
+		var opacity = isNumber(inline.opacity) ? inline.opacity : 1;
+		pdfKitDoc.opacity(opacity);
 		pdfKitDoc.fill(inline.color || 'black');
 
 		pdfKitDoc._font = inline.font;
@@ -586,22 +587,26 @@ function renderVector(vector, pdfKitDoc) {
 
 		vector.color = gradient;
 	}
+               
+	var fillOpacity = isNumber(vector.fillOpacity) ? vector.fillOpacity : 1;
+	var strokeOpacity = isNumber(vector.strokeOpacity) ? vector.strokeOpacity : 1;
 
 	if (vector.color && vector.lineColor) {
-		pdfKitDoc.fillColor(vector.color, vector.fillOpacity || 1);
-		pdfKitDoc.strokeColor(vector.lineColor, vector.strokeOpacity || 1);
+		pdfKitDoc.fillColor(vector.color, fillOpacity);
+		pdfKitDoc.strokeColor(vector.lineColor, strokeOpacity);
 		pdfKitDoc.fillAndStroke();
 	} else if (vector.color) {
-		pdfKitDoc.fillColor(vector.color, vector.fillOpacity || 1);
+		pdfKitDoc.fillColor(vector.color, fillOpacity);
 		pdfKitDoc.fill();
 	} else {
-		pdfKitDoc.strokeColor(vector.lineColor || 'black', vector.strokeOpacity || 1);
+		pdfKitDoc.strokeColor(vector.lineColor || 'black', strokeOpacity);
 		pdfKitDoc.stroke();
 	}
 }
 
 function renderImage(image, x, y, pdfKitDoc) {
-	pdfKitDoc.opacity(image.opacity || 1);
+	var opacity = isNumber(image.opacity) ? image.opacity : 1;
+	pdfKitDoc.opacity(opacity);
 	pdfKitDoc.image(image.image, image.x, image.y, { width: image._width, height: image._height });
 	if (image.link) {
 		pdfKitDoc.link(image.x, image.y, image._width, image._height, image.link);


### PR DESCRIPTION
This is a fix proposal for Issue #1917.

Opacity attributes are used in test conditions like: `opacity = opacity || <default_value>;` .
So, for any opacity set to 0, the Boolean conversion of zero into a `false` causes `opacity` to be set to `<default_value>`.

The fix consists in checking that opacity attributes are numbers with call of the `isNumber` helper in the test condition such as : `opacity = isNumber(opacity) ? opacity : <default_value>;`

The patch has been done using the `0.1` branch as it is the stable branch. Please let me know if you prefer a path based on the `master` branch.