### PR TITLE
Colors with opacity at zero now fully transparent

### DIFF
--- a/src/LayoutBuilder.js
+++ b/src/LayoutBuilder.js
@@ -5,7 +5,7 @@ import PageElementWriter from './PageElementWriter';
 import ColumnCalculator from './columnCalculator';
 import TableProcessor from './TableProcessor';
 import Line from './Line';
-import { isString, isArray, isFunction, isValue } from './helpers/variableType';
+import { isString, isArray, isFunction, isValue, isNumber } from './helpers/variableType';
 import { stringifyNode, getNodeId } from './helpers/node';
 import { pack, offsetVector } from './helpers/tools';
 import TextInlines from './TextInlines';
@@ -243,7 +243,7 @@ class LayoutBuilder {
 		watermark.font = watermark.font || defaultStyle.font || 'Roboto';
 		watermark.fontSize = watermark.fontSize || 'auto';
 		watermark.color = watermark.color || 'black';
-		watermark.opacity = watermark.opacity || 0.6;
+		watermark.opacity = isNumber(watermark.opacity) ? watermark.opacity : 0.6;
 		watermark.bold = watermark.bold || false;
 		watermark.italics = watermark.italics || false;
 		watermark.angle = isValue(watermark.angle) ? watermark.angle : null;

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -1,5 +1,6 @@
 import TextDecorator from './TextDecorator';
 import TextInlines from './TextInlines';
+import {isNumber} from './helpers/variableType';
 
 var getSvgToPDF = function () {
 	try {
@@ -154,8 +155,9 @@ class Renderer {
 			if (inline.fontFeatures) {
 				options.features = inline.fontFeatures;
 			}
-
-			this.pdfDocument.opacity(inline.opacity || 1);
+                        
+			var opacity = isNumber(inline.opacity) ? inline.opacity : 1;
+			this.pdfDocument.opacity(opacity);
 			this.pdfDocument.fill(inline.color || 'black');
 
 			this.pdfDocument._font = inline.font;
@@ -244,21 +246,25 @@ class Renderer {
 			vector.color = gradient;
 		}
 
+		var fillOpacity = isNumber(vector.fillOpacity) ? vector.fillOpacity : 1;
+		var strokeOpacity = isNumber(vector.strokeOpacity) ? vector.strokeOpacity : 1;
+
 		if (vector.color && vector.lineColor) {
-			this.pdfDocument.fillColor(vector.color, vector.fillOpacity || 1);
-			this.pdfDocument.strokeColor(vector.lineColor, vector.strokeOpacity || 1);
+			this.pdfDocument.fillColor(vector.color, fillOpacity);
+			this.pdfDocument.strokeColor(vector.lineColor, strokeOpacity);
 			this.pdfDocument.fillAndStroke();
 		} else if (vector.color) {
-			this.pdfDocument.fillColor(vector.color, vector.fillOpacity || 1);
+			this.pdfDocument.fillColor(vector.color, fillOpacity);
 			this.pdfDocument.fill();
 		} else {
-			this.pdfDocument.strokeColor(vector.lineColor || 'black', vector.strokeOpacity || 1);
+			this.pdfDocument.strokeColor(vector.lineColor || 'black', strokeOpacity);
 			this.pdfDocument.stroke();
 		}
 	}
 
 	renderImage(image) {
-		this.pdfDocument.opacity(image.opacity || 1);
+		var opacity = isNumber(image.opacity) ? image.opacity : 1;
+		this.pdfDocument.opacity(opacity);
 		this.pdfDocument.image(image.image, image.x, image.y, { width: image._width, height: image._height });
 		if (image.link) {
 			this.pdfDocument.link(image.x, image.y, image._width, image._height, image.link);


### PR DESCRIPTION
Hi Libor,

Further to your comment in PR #1918, please find a new PR with a branch based upon master to fix Issue #1917. 

Like for the previous PR, I tested with the example provided in the Issue.
Performed following operations:
- Ran the test suite: `npm run test`
- Ran dev-playground locally (`nodemon ./dev-playground/server.js`).
- Tested built `pdfmake.js` lib for test in a browser.

Please note that with the current master HEAD (prior my changes), I was not able to test in a browser with a rendering in an iframe (copy /paste code from the [pdfmake docs.](https://pdfmake.github.io/docs/getting-started/client-side/methods/)).

I used instead `pdfMake.createPdf(docDefinition).download();` which still works. I don't think it is a  issue from my setup because it works with a `pdfmake.js` lib built from the `0.1` branch.
