### PR TITLE
support cover for image element

### DIFF
--- a/examples/images.js
+++ b/examples/images.js
@@ -30,6 +30,12 @@ var docDefinition = {
 			fit: [100, 100],
 			pageBreak: 'after'
 		},
+		'You can also cover the image inside a rectangle',
+		{
+			image: 'fonts/sampleImage.jpg',
+			cover: {width: 100, height: 100, valign: "bottom", align: "right"},
+			pageBreak: 'after'
+		},
 		'Images can be also provided in dataURL format\n(the one below was taken from http://www.clipartbest.com/clipart-dT7zx5rT9)',
 		{
 			image: testImageDataUrl,

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -288,7 +288,18 @@ class Renderer {
 	renderImage(image) {
 		let opacity = isNumber(image.opacity) ? image.opacity : 1;
 		this.pdfDocument.opacity(opacity);
-		this.pdfDocument.image(image.image, image.x, image.y, { width: image._width, height: image._height });
+		if (image.cover) {
+			const align = image.cover.align || 'center';
+			const valign = image.cover.valign ||'center';
+			const width = image.cover.width ? image.cover.width : image.width;
+			const height = image.cover.height ? image.cover.height : image.height;
+			this.pdfDocument.save();
+			this.pdfDocument.rect(image.x, image.y, width, height).clip();
+			this.pdfDocument.image(image.image, image.x, image.y, { cover: [width, height], align, valign});
+			this.pdfDocument.restore();
+		} else {
+			this.pdfDocument.image(image.image, image.x, image.y, { width: image._width, height: image._height });
+		}
 		if (image.link) {
 			this.pdfDocument.link(image.x, image.y, image._width, image._height, image.link);
 		}


### PR DESCRIPTION
Thank you for great library.

Based on  #1906, I created PR.
It support cover option for image element.
It's a little different from this ticket, but it's used like this.

```
 {
   image: "coverImage", 
   cover: {width:  300, height: 150, valign: "bottom", align: "center" }  
  }
```

Unit tests have passed. 
Please let us know if you have any other work for merge.

Thanks.
