### PR TITLE
fix(table): dontBreakRows not fitting on single page #1159

### DIFF
--- a/src/ElementWriter.js
+++ b/src/ElementWriter.js
@@ -336,7 +336,7 @@ class ElementWriter extends EventEmitter {
 	 */
 	pushContext(contextOrWidth, height) {
 		if (contextOrWidth === undefined) {
-			height = (this.context.getCurrentPage().height || this.context.getCurrentPage().pageSize.height) - this.context().pageMargins.top - this.context().pageMargins.bottom;
+			height = (this.context().getCurrentPage().height || this.context().getCurrentPage().pageSize.height) - this.context().pageMargins.top - this.context().pageMargins.bottom;
 			contextOrWidth = this.context().availableWidth;
 		}
 

--- a/src/ElementWriter.js
+++ b/src/ElementWriter.js
@@ -336,7 +336,7 @@ class ElementWriter extends EventEmitter {
 	 */
 	pushContext(contextOrWidth, height) {
 		if (contextOrWidth === undefined) {
-			height = this.context().getCurrentPage().height - this.context().pageMargins.top - this.context().pageMargins.bottom;
+			height = (this.context.getCurrentPage().height || this.context.getCurrentPage().pageSize.height) - this.context().pageMargins.top - this.context().pageMargins.bottom;
 			contextOrWidth = this.context().availableWidth;
 		}
 

--- a/src/PageElementWriter.js
+++ b/src/PageElementWriter.js
@@ -86,9 +86,8 @@ class PageElementWriter extends ElementWriter {
 			this.popContext();
 
 			let nbPages = unbreakableContext.pages.length;
-			if (nbPages > 0) {
-				// no support for multi-page unbreakableBlocks
-				let fragment = unbreakableContext.pages[0];
+			for (let currentPage = 0; currentPage < nbPages; currentPage++) {
+				let fragment = unbreakableContext.pages[currentPage];
 				fragment.xOffset = forcedX;
 				fragment.yOffset = forcedY;
 


### PR DESCRIPTION
Should fix issue #1159 related to dontBreakRows that would completely remove the row if it would not fit on a single page