### PR TITLE
Performance problem when pageBreakBefore for large files used fixed

### DIFF
--- a/src/LayoutBuilder.js
+++ b/src/LayoutBuilder.js
@@ -85,7 +85,7 @@ class LayoutBuilder {
 					}
 				});
 				nodeInfo.startPosition = node.positions[0];
-				nodeInfo.pageNumbers = node.positions.map(node => node.pageNumber).filter((element, position, array) => array.indexOf(element) === position);
+				nodeInfo.pageNumbers = Array.from(new Set(node.positions.map(node => node.pageNumber)));
 				nodeInfo.pages = pages.length;
 				nodeInfo.stack = isArray(node.stack);
 


### PR DESCRIPTION
I've fixed the problematic line with creating Set that is better in performance.
Before for 300 page document algorithm spends about minute on this line every page so ~300 minutes.
Now it takes milliseconds.
Try it and pull.
Thank you, i love this library