### PR TITLE
Performance problem when pageBreakBefore for large files used fixed (v0.1)

### DIFF
--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -81,11 +81,7 @@ LayoutBuilder.prototype.layoutDocument = function (docStructure, fontProvider, s
 				}
 			});
 			nodeInfo.startPosition = node.positions[0];
-			nodeInfo.pageNumbers = node.positions.map(function (node) {
-				return node.pageNumber;
-			}).filter(function (element, position, array) {
-				return array.indexOf(element) === position;
-			});
+			nodeInfo.pageNumbers = new Set(node.positions.map(function (node) {return node.pageNumber;}));
 			nodeInfo.pages = pages.length;
 			nodeInfo.stack = isArray(node.stack);
 
@@ -100,17 +96,21 @@ LayoutBuilder.prototype.layoutDocument = function (docStructure, fontProvider, s
 				var followingNodesOnPage = [];
 				var nodesOnNextPage = [];
 				var previousNodesOnPage = [];
-				for (var ii = index + 1, l = linearNodeList.length; ii < l; ii++) {
-					if (linearNodeList[ii].nodeInfo.pageNumbers.indexOf(pageNumber) > -1) {
-						followingNodesOnPage.push(linearNodeList[ii].nodeInfo);
-					}
-					if (linearNodeList[ii].nodeInfo.pageNumbers.indexOf(pageNumber + 1) > -1) {
-						nodesOnNextPage.push(linearNodeList[ii].nodeInfo);
+				if(pageBreakBeforeFct.length>1){
+					for (var ii = index + 1, l = linearNodeList.length; ii < l; ii++) {
+						if (linearNodeList[ii].nodeInfo.pageNumbers.indexOf(pageNumber) > -1) {
+							followingNodesOnPage.push(linearNodeList[ii].nodeInfo);
+						}
+						if (pageBreakBeforeFct.length>2&&linearNodeList[ii].nodeInfo.pageNumbers.indexOf(pageNumber + 1) > -1) {
+							nodesOnNextPage.push(linearNodeList[ii].nodeInfo);
+						}
 					}
 				}
-				for (var ii = 0; ii < index; ii++) {
-					if (linearNodeList[ii].nodeInfo.pageNumbers.indexOf(pageNumber) > -1) {
-						previousNodesOnPage.push(linearNodeList[ii].nodeInfo);
+				if(pageBreakBeforeFct.length>3){
+					for (var ii = 0; ii < index; ii++) {
+						if (linearNodeList[ii].nodeInfo.pageNumbers.indexOf(pageNumber) > -1) {
+							previousNodesOnPage.push(linearNodeList[ii].nodeInfo);
+						}
 					}
 				}
 				if (pageBreakBeforeFct(node.nodeInfo, followingNodesOnPage, nodesOnNextPage, previousNodesOnPage)) {

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -81,7 +81,7 @@ LayoutBuilder.prototype.layoutDocument = function (docStructure, fontProvider, s
 				}
 			});
 			nodeInfo.startPosition = node.positions[0];
-			nodeInfo.pageNumbers = new Set(node.positions.map(function (node) {return node.pageNumber;}));
+			nodeInfo.pageNumbers = Array.from(new Set(node.positions.map(function (node) {return node.pageNumber;})));
 			nodeInfo.pages = pages.length;
 			nodeInfo.stack = isArray(node.stack);
 

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1833,7 +1833,7 @@ describe('LayoutBuilder', function () {
 			];
 
 			pageBreakBeforeFunction = sinon.spy();
-
+			pageBreakBeforeFunction.length = 2;
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 
@@ -1852,6 +1852,7 @@ describe('LayoutBuilder', function () {
 			};
 
 			pageBreakBeforeFunction = sinon.spy();
+			pageBreakBeforeFunction.length = 3;
 
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
@@ -1871,6 +1872,7 @@ describe('LayoutBuilder', function () {
 			};
 
 			pageBreakBeforeFunction = sinon.spy();
+			pageBreakBeforeFunction.length = 4;
 
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);

--- a/tests/layoutBuilder.js
+++ b/tests/layoutBuilder.js
@@ -1832,8 +1832,8 @@ describe('LayoutBuilder', function () {
 				{ text: 'Text 4 (Page 2)', id: 'text4', pageBreak: 'before' }
 			];
 
-			pageBreakBeforeFunction = sinon.spy();
-			pageBreakBeforeFunction.length = 2;
+			function functionOfLength2(a,b) {}
+			pageBreakBeforeFunction = sinon.spy(functionOfLength2);
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 
@@ -1851,9 +1851,8 @@ describe('LayoutBuilder', function () {
 				id: 'stack'
 			};
 
-			pageBreakBeforeFunction = sinon.spy();
-			pageBreakBeforeFunction.length = 3;
-
+			function functionOfLength3(a,b,c) {}
+			pageBreakBeforeFunction = sinon.spy(functionOfLength3);
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 
@@ -1871,9 +1870,8 @@ describe('LayoutBuilder', function () {
 				id: 'stack'
 			};
 
-			pageBreakBeforeFunction = sinon.spy();
-			pageBreakBeforeFunction.length = 4;
-
+			function functionOfLength4(a,b,c,d) {}
+			pageBreakBeforeFunction = sinon.spy(functionOfLength4);
 
 			builder.layoutDocument(docStructure, fontProvider, styleDictionary, defaultStyle, background, header, footer, images, watermark, pageBreakBeforeFunction);
 


### PR DESCRIPTION
The same fix but for v0.1.
creating Set is the same
I also check length of arguments in functions and if no functions are used, the arrays will not be evaluated.
Please check and pull. It will be great if you make release becouse I use this lib