### PR TITLE
attachments embedding with text #956

### DIFF
--- a/src/Line.js
+++ b/src/Line.js
@@ -98,6 +98,31 @@ class Line {
 		return (this.inlineWidths + inlineWidth - this.leadingCut - inlineTrailingCut) <= this.maxWidth;
 	}
 
+	optimizeInlines() {
+		this.inlines = this.inlines.reduce((inlines, inline) => {
+			const previous = inlines.pop();
+			if (!previous) {
+				return [inline];
+			}
+
+			// unique set of all keys present in previous and current element except 'text', 'x', 'width', 'leadingCut', 'trailingCut'
+			const keysToCompare = [...new Set(Object.keys(previous).concat(Object.keys(inline)))]
+				.filter(key => !['text', 'x', 'width', 'leadingCut', 'trailingCut'].includes(key));
+
+			for (const key of keysToCompare) {
+				if (previous[key] !== inline[key]) {
+					inlines.push(previous, inline);
+					return inlines;
+				}
+			}
+			previous.text += inline.text;
+			previous.width += inline.width;
+			previous.trailingCut = inline.trailingCut;
+			inlines.push(previous);
+			return inlines;
+		}, []);
+	}
+
 	clone() {
 		let result = new Line(this.maxWidth);
 

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -193,6 +193,27 @@ class Renderer {
 				this.pdfDocument.ref({ Type: 'Action', S: 'GoTo', D: [inline.linkToPage, 0, 0] }).end();
 				this.pdfDocument.annotate(x + inline.x, shiftedY, inline.width, inline.height, { Subtype: 'Link', Dest: [inline.linkToPage - 1, 'XYZ', null, null, null] });
 			}
+			if (inline.linkToFile) {
+				const attachment = this.pdfDocument.provideAttachment(inline.linkToFile);
+				this.pdfDocument.fileAnnotation(
+					x + inline.x,
+					shiftedY,
+					inline.width,
+					inline.height,
+					attachment,
+					// add empty rectangle as file annotation appearance with the same size as the rendered inline
+					{
+						AP: {
+							N: {
+								Type: 'XObject',
+								Subtype: 'Form',
+								FormType: 1,
+								BBox: [x + inline.x, shiftedY, inline.width, inline.height]
+							}
+						},
+					}
+				);
+			}
 		}
 
 		// Decorations won't draw correctly for superscript

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -150,8 +150,7 @@ class Renderer {
 
 		textDecorator.drawBackground(line, x, y);
 
-		//TODO: line.optimizeInlines();
-		//TOOD: lines without differently styled inlines should be written to pdf as one stream
+		line.optimizeInlines();
 		for (let i = 0, l = line.inlines.length; i < l; i++) {
 			let inline = line.inlines[i];
 			let shiftToBaseline = lineHeight - ((inline.font.ascender / 1000) * inline.fontSize) - descent;

--- a/src/TextInlines.js
+++ b/src/TextInlines.js
@@ -121,6 +121,7 @@ class TextInlines {
 			item.link = StyleContextStack.getStyleProperty(item, styleContextStack, 'link', null);
 			item.linkToPage = StyleContextStack.getStyleProperty(item, styleContextStack, 'linkToPage', null);
 			item.linkToDestination = StyleContextStack.getStyleProperty(item, styleContextStack, 'linkToDestination', null);
+			item.linkToFile = StyleContextStack.getStyleProperty(item, styleContextStack, 'linkToFile', null);
 			item.noWrap = StyleContextStack.getStyleProperty(item, styleContextStack, 'noWrap', null);
 			item.opacity = StyleContextStack.getStyleProperty(item, styleContextStack, 'opacity', 1);
 			item.sup = StyleContextStack.getStyleProperty(item, styleContextStack, 'sup', false);

--- a/tests/unit/Line.spec.js
+++ b/tests/unit/Line.spec.js
@@ -184,4 +184,82 @@ describe('Line', function () {
 
 		// TODO: test for nextInlines with noNewLine
 	});
+
+	describe('optimizeInlines', function () {
+		it('should optimize inlines with the same style', function () {
+			var line = new Line(1000);
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 0, trailingCut: 2.97 });
+			line.optimizeInlines();
+			assert.strictEqual(line.inlines.length, 1);
+			assert.strictEqual(line.inlines[0].text, 'Inline text works ');
+			assert.strictEqual(line.inlines[0].width, 31.69 + 23.14 + 32.20);
+		});
+
+		it('should not optimize inlines with different styles', function () {
+			var line = new Line(1000);
+			line.addInline({ text: 'Bigger', fontSize: 15, height: 17.57, width: 42.87, leadingCut: 0, trailingCut: 0 });
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 0, trailingCut: 2.97 });
+			line.optimizeInlines();
+			assert.strictEqual(line.inlines.length, 2);
+			assert.strictEqual(line.inlines[0].text, 'Bigger');
+			assert.strictEqual(line.inlines[1].text, 'Inline text works ');
+			assert.strictEqual(line.inlines[1].width, 31.69 + 23.14 + 32.20);
+		});
+
+		it('should set x to x of the first optimized inline', function () {
+			var line = new Line(1000);
+			line.addInline({ text: 'Bigger', fontSize: 15, height: 17.57, width: 42.87, leadingCut: 0, trailingCut: 0 });
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 0, trailingCut: 2.97 });
+			line.optimizeInlines();
+			assert.strictEqual(line.inlines[0].x, 0);
+			assert.strictEqual(line.inlines[1].x, 42.87); // sum of preceding inline widths minus first inline leadingCut
+		});
+
+		it('should set leadingCut to leadingCut of the first optimized inline', function () {
+			var line = new Line(1000);
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 20, trailingCut: 2.97 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 10, trailingCut: 2.97 });
+			line.optimizeInlines();
+			assert.strictEqual(line.inlines[0].leadingCut, 20);
+		});
+
+		it('should set trailingCut the trailingCut of the last optimized inline', function () {
+			var line = new Line(1000);
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 0, trailingCut: 0 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 10 });
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 0, trailingCut: 2.97 });
+			line.optimizeInlines();
+			assert.strictEqual(line.inlines[0].trailingCut, 2.97);
+		});
+
+		it('should optimize chunks of inlines with the same style', function () {
+			var line = new Line(1000);
+			// chunk 0
+			line.addInline({ text: 'Bigger', fontSize: 15, height: 17.57, width: 42.87, leadingCut: 0, trailingCut: 0 });
+			// chunk 1
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 0, trailingCut: 2.97 });
+			// chunk 2
+			line.addInline({ text: 'Bigger', fontSize: 15, height: 17.57, width: 42.87, leadingCut: 0, trailingCut: 0 });
+			// chunk 3
+			line.addInline({ text: 'Inline ', fontSize: 12, height: 14.06, width: 31.69, leadingCut: 0, trailingCut: 2.97 });
+			line.addInline({ text: 'text ', fontSize: 12, height: 14.06, width: 23.14, leadingCut: 0, trailingCut: 2.97 });
+			// chunk 4
+			line.addInline({ text: 'Bigger', fontSize: 15, height: 17.57, width: 42.87, leadingCut: 0, trailingCut: 0 });
+			// chunk 5
+			line.addInline({ text: 'works ', fontSize: 12, height: 14.06, width: 32.20, leadingCut: 0, trailingCut: 2.97 });
+			line.optimizeInlines();
+			assert.strictEqual(line.inlines.length, 6);
+			assert.strictEqual(line.inlines[1].text, 'Inline text works ');
+			assert.strictEqual(line.inlines[3].text, 'Inline text ');
+		});
+	});
 });


### PR DESCRIPTION
Adding functionality to embed attachments with `{ text: '', linkToFile: … }` as well as Line.optimizeInlines() in order to minimize the number of fileAnnotations per line of text.
(Works great with `{ style: 'icon' }`!)

I'm not 100% confident that optimizeInlines doesn't break in some cases, but it seems to work perfectly for everything I tested - tests run as well.
