### PR TITLE
migrate away from the fork of foliojs packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "test": "tests"
   },
   "dependencies": {
-    "@foliojs-fork/linebreak": "^1.1.1",
-    "@foliojs-fork/pdfkit": "^0.13.0",
     "iconv-lite": "^0.6.3",
+    "linebreak": "^1.1.0",
+    "pdfkit": "^0.13.0",
     "xmldoc": "^1.1.2"
   },
   "devDependencies": {

--- a/src/PDFDocument.js
+++ b/src/PDFDocument.js
@@ -1,4 +1,4 @@
-import PDFKit from '@foliojs-fork/pdfkit';
+import PDFKit from "pdfkit";
 
 const typeName = (bold, italics) => {
 	let type = 'normal';

--- a/src/TextBreaker.js
+++ b/src/TextBreaker.js
@@ -1,4 +1,4 @@
-import LineBreaker from '@foliojs-fork/linebreak';
+import LineBreaker from 'linebreak';
 import { isObject } from './helpers/variableType';
 import StyleContextStack from './StyleContextStack';
 

--- a/src/browser-extensions/standard-fonts/Courier.js
+++ b/src/browser-extensions/standard-fonts/Courier.js
@@ -2,10 +2,10 @@ var fs = require('fs');
 
 var fontContainer = {
 	vfs: {
-		'data/Courier.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Courier.afm', 'utf8'), encoding: 'utf8' },
-		'data/Courier-Bold.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Courier-Bold.afm', 'utf8'), encoding: 'utf8' },
-		'data/Courier-Oblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Courier-Oblique.afm', 'utf8'), encoding: 'utf8' },
-		'data/Courier-BoldOblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Courier-BoldOblique.afm', 'utf8'), encoding: 'utf8' }
+		'data/Courier.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Courier.afm', 'utf8'), encoding: 'utf8' },
+		'data/Courier-Bold.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Courier-Bold.afm', 'utf8'), encoding: 'utf8' },
+		'data/Courier-Oblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Courier-Oblique.afm', 'utf8'), encoding: 'utf8' },
+		'data/Courier-BoldOblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Courier-BoldOblique.afm', 'utf8'), encoding: 'utf8' }
 	},
 	fonts: {
 		Courier: {

--- a/src/browser-extensions/standard-fonts/Helvetica.js
+++ b/src/browser-extensions/standard-fonts/Helvetica.js
@@ -2,10 +2,10 @@ var fs = require('fs');
 
 var fontContainer = {
 	vfs: {
-		'data/Helvetica.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Helvetica.afm', 'utf8'), encoding: 'utf8' },
-		'data/Helvetica-Bold.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Helvetica-Bold.afm', 'utf8'), encoding: 'utf8' },
-		'data/Helvetica-Oblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Helvetica-Oblique.afm', 'utf8'), encoding: 'utf8' },
-		'data/Helvetica-BoldOblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Helvetica-BoldOblique.afm', 'utf8'), encoding: 'utf8' }
+		'data/Helvetica.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Helvetica.afm', 'utf8'), encoding: 'utf8' },
+		'data/Helvetica-Bold.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Helvetica-Bold.afm', 'utf8'), encoding: 'utf8' },
+		'data/Helvetica-Oblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Helvetica-Oblique.afm', 'utf8'), encoding: 'utf8' },
+		'data/Helvetica-BoldOblique.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Helvetica-BoldOblique.afm', 'utf8'), encoding: 'utf8' }
 	},
 	fonts: {
 		Helvetica: {

--- a/src/browser-extensions/standard-fonts/Symbol.js
+++ b/src/browser-extensions/standard-fonts/Symbol.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 
 var fontContainer = {
 	vfs: {
-		'data/Symbol.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Symbol.afm', 'utf8'), encoding: 'utf8' }
+		'data/Symbol.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Symbol.afm', 'utf8'), encoding: 'utf8' }
 	},
 	fonts: {
 		Symbol: {

--- a/src/browser-extensions/standard-fonts/Times.js
+++ b/src/browser-extensions/standard-fonts/Times.js
@@ -2,10 +2,10 @@ var fs = require('fs');
 
 var fontContainer = {
 	vfs: {
-		'data/Times-Roman.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Times-Roman.afm', 'utf8'), encoding: 'utf8' },
-		'data/Times-Bold.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Times-Bold.afm', 'utf8'), encoding: 'utf8' },
-		'data/Times-Italic.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Times-Italic.afm', 'utf8'), encoding: 'utf8' },
-		'data/Times-BoldItalic.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/Times-BoldItalic.afm', 'utf8'), encoding: 'utf8' }
+		'data/Times-Roman.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Times-Roman.afm', 'utf8'), encoding: 'utf8' },
+		'data/Times-Bold.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Times-Bold.afm', 'utf8'), encoding: 'utf8' },
+		'data/Times-Italic.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Times-Italic.afm', 'utf8'), encoding: 'utf8' },
+		'data/Times-BoldItalic.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/Times-BoldItalic.afm', 'utf8'), encoding: 'utf8' }
 	},
 	fonts: {
 		Times: {

--- a/src/browser-extensions/standard-fonts/ZapfDingbats.js
+++ b/src/browser-extensions/standard-fonts/ZapfDingbats.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 
 var fontContainer = {
 	vfs: {
-		'data/ZapfDingbats.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/@foliojs-fork/pdfkit/js/data/ZapfDingbats.afm', 'utf8'), encoding: 'utf8' }
+		'data/ZapfDingbats.afm': { data: fs.readFileSync(__dirname + '/../../../node_modules/pdfkit/js/data/ZapfDingbats.afm', 'utf8'), encoding: 'utf8' }
 	},
 	fonts: {
 		ZapfDingbats: {


### PR DESCRIPTION
Closes #2492

`npm run test` and `npm run build` both worked, it looks like some linter changes also made their way into the PR, hopefully that's still fine