### PR TITLE
feat: add padding option of qrcode for set qrcode padding.

### DIFF
--- a/examples/qrCode.js
+++ b/examples/qrCode.js
@@ -31,8 +31,13 @@ var docDefinition = {
 		header('A very long text (' + longText.length + ' chars)'),
 		{ qr: longText },
 		'\n',
+
 		header('same long text with fit = 100 and alignment = right'),
 		{ qr: longText, fit: 150, alignment: 'right' },
+		'\n',
+
+		header('same long text with fit = 100 and padding = 1 modules in pixel'),
+		{ qr: longText, fit: 150, padding: 1 },
 	]
 };
 

--- a/src/qrEnc.js
+++ b/src/qrEnc.js
@@ -748,11 +748,13 @@ function buildCanvas(data, options) {
 	var canvas = [];
 	var background = options.background || '#fff';
 	var foreground = options.foreground || '#000';
+	var padding = options.padding || 0;
 	//var margin = options.margin || 4;
 	var matrix = generateFrame(data, options);
 	var n = matrix.length;
 	var modSize = Math.floor(options.fit ? options.fit / n : 5);
-	var size = n * modSize;
+	var size = (n * modSize) + (modSize * padding * 2);
+	var paddingXY = modSize * padding;
 
 	canvas.push({
 		type: 'rect',
@@ -764,8 +766,8 @@ function buildCanvas(data, options) {
 			if (matrix[i][j]) {
 				canvas.push({
 					type: 'rect',
-					x: modSize * j,
-					y: modSize * i,
+					x: modSize * j + paddingXY,
+					y: modSize * i + paddingXY,
 					w: modSize,
 					h: modSize,
 					lineWidth: 0,


### PR DESCRIPTION
I have add padding option of qrcode for set qrcode padding.

User can set option of qrcode with `padding` field following example below.

```
{ qr: "my message", fit: 150, padding: 1 }
```

Output:
<img width="211" alt="image" src="https://user-images.githubusercontent.com/7018802/231242849-2cb067a9-f4f3-4f58-b612-4d06a63b1076.png">
