### PR TITLE
Feature: RTL support

### DIFF
--- a/src/elementWriter.js
+++ b/src/elementWriter.js
@@ -221,7 +221,7 @@ ElementWriter.prototype.endClip = function () {
 };
 
 function cloneLine(line) {
-	var result = new Line(line.maxWidth);
+	var result = new Line(line.maxWidth, line.direction);
 
 	for (var key in line) {
 		if (line.hasOwnProperty(key)) {

--- a/src/layoutBuilder.js
+++ b/src/layoutBuilder.js
@@ -617,7 +617,7 @@ LayoutBuilder.prototype.processList = function (orderedList, node) {
 				offsetVector(vector, -marker._minWidth, 0);
 				self.writer.addVector(vector);
 			} else if (marker._inlines) {
-				var markerLine = new Line(self.pageSize.width);
+				var markerLine = new Line(self.pageSize.width, node.direction);
 				markerLine.addInline(marker._inlines[0]);
 				markerLine.x = -marker._minWidth;
 				markerLine.y = line.getAscenderHeight() - markerLine.getAscenderHeight();
@@ -728,7 +728,7 @@ LayoutBuilder.prototype.buildNextLine = function (textNode) {
 		return null;
 	}
 
-	var line = new Line(this.writer.context().availableWidth);
+	var line = new Line(this.writer.context().availableWidth, textNode.direction);
 	var textTools = new TextTools(null);
 
 	var isForceContinue = false;

--- a/src/line.js
+++ b/src/line.js
@@ -7,8 +7,9 @@
  * @this {Line}
  * @param {Number} Maximum width this line can have
  */
-function Line(maxWidth) {
+function Line(maxWidth, direction = 'ltr') {
 	this.maxWidth = maxWidth;
+	this.direction = direction;
 	this.leadingCut = 0;
 	this.trailingCut = 0;
 	this.inlineWidths = 0;
@@ -59,22 +60,42 @@ Line.prototype.addInline = function (inline) {
 	this.trailingCut = inline.trailingCut || 0;
 
 	var isRTLInline = inline.text.match(this.inlineRTLRegex);
+	var isRTLDirection = this.direction === 'rtl';
 
-	if (isRTLInline) {
-		// ltr direction & rtl inline.
-		var inlineIndex = this._inlines.length;
-		for(var i = this._inlines.length - 1; i >= 0; i--) {
-			if (this._inlines[i].text.match(this.inlineRTLRegex)) {
-				inlineIndex = i;
-			} else {
-				break;
+	if (isRTLDirection) {
+		if (isRTLInline) {
+			// rtl direction & rtl inline.
+			this._inlines.unshift(inline);
+		} else {
+			// rtl direction & ltr inline.
+			var inlineIndex = 0;
+			for(var i = 0; i < this._inlines.length; i++) {
+				if (!this._inlines[i].text.match(this.inlineRTLRegex)) {
+					inlineIndex = i + 1;
+				} else {
+					break;
+				}
 			}
-		}
 
-		this._inlines.splice(inlineIndex, 0, inline);
+			this._inlines.splice(inlineIndex, 0, inline);
+		}
 	} else {
-		// ltr direction & ltr inline.
-		this._inlines.push(inline);
+		if (isRTLInline) {
+			// ltr direction & rtl inline.
+			var inlineIndex = this._inlines.length;
+			for(var i = this._inlines.length - 1; i >= 0; i--) {
+				if (this._inlines[i].text.match(this.inlineRTLRegex)) {
+					inlineIndex = i;
+				} else {
+					break;
+				}
+			}
+
+			this._inlines.splice(inlineIndex, 0, inline);
+		} else {
+			// ltr direction & ltr inline.
+			this._inlines.push(inline);
+		}
 	}
 
 	this.inlineWidths += inline.width;


### PR DESCRIPTION
Hello,

After being shocked that awesome library doesn't fully support RTL. I tried to do it.

Supporting RTL languages isn't straight forward. Firstly I thought it would be through pdfkit but I found that pdfmake is splitting words and send word by word to pdfkit, so it would be useless to do that through pdfkit.

This pull request fixes 2 separate issues for RTL:
1. Inserting RTL words (inlines) with the correct order in the line even with LTR direction. (Example: `One اثنان ثلاثة Four` However `ثلاثة` is after `اثنان` but it should be before it.)
2. Add support of RTL direction. You can compare results with browser <textarea /> with using both directions. You'll see the same results.

There are still 2 minor issues for RTL languages but they are related to fontkit engine or pdfkit I am not sure.
1. Arabic (Hindi) numbers is reversed by fontkit like Arabic letters while they shouldn't be reversed. (Arabic and English numbers are written in the same direction always LTR)
2. If there is a combined word with Arabic and English (by mistake), fontkit also reverse the English characters :)

These are minor issues and can be easily avoided by not using Arabic (Hindi) numbers or manually reversing them & by ensuring that every word contains either Arabic or English character. But it will be great if fontkit fix it :)

**Update:** This pull request seems to be working fine with wrapped text, I think non-wrapped text are not being splitted and therefore should be fixed from pdfkit ?