### PR TITLE
Fixes #875 and #2582

### DIFF
--- a/src/DocMeasure.js
+++ b/src/DocMeasure.js
@@ -433,16 +433,17 @@ class DocMeasure {
 				if (item.listMarker._inlines) {
 					node._gapSize.width = Math.max(node._gapSize.width, item.listMarker._inlines[0].width);
 				}
-			}  // TODO: else - nested lists numbering
+
+				if (node.reversed) {
+					counter--;
+				} else {
+					counter++;
+				}
+			}
 
 			node._minWidth = Math.max(node._minWidth, items[i]._minWidth);
 			node._maxWidth = Math.max(node._maxWidth, items[i]._maxWidth);
 
-			if (node.reversed) {
-				counter--;
-			} else {
-				counter++;
-			}
 		}
 
 		node._minWidth += node._gapSize.width;

--- a/tests/unit/DocMeasure.spec.js
+++ b/tests/unit/DocMeasure.spec.js
@@ -180,6 +180,14 @@ describe('DocMeasure', function () {
 			assert(result._gapSize);
 		});
 
+		it('should not increase listMarker when list item is a nested list', function () {
+			var node = { ol: ['parent item 1', { ol: ['nested item 1', 'nested item 2']}, 'parent item 2'] };
+			docPreprocessor.preprocessList(node);
+			var result = docMeasure.measureOrderedList(node);
+
+			assert.equal(result.ol[2].listMarker._inlines[0].text, '2. ');
+		});
+
 		it('should calculate _minWidth and _maxWidth of all elements', function () {
 			var node = { ol: ['this is a test', 'another one'] };
 			docPreprocessor.preprocessList(node);


### PR DESCRIPTION
This pull request fixes issues [#875](https://github.com/bpampuch/pdfmake/issues/875) and [#2582](https://github.com/bpampuch/pdfmake/issues/2582) by not increasing the counter of the list marker when list item is a list (nested list)