### PR TITLE
Fixes issues 2069 2189 1545 668 997 1654

### DIFF
--- a/src/DocumentContext.js
+++ b/src/DocumentContext.js
@@ -18,7 +18,6 @@ class DocumentContext extends EventEmitter {
 		this.page = -1;
 
 		this.snapshots = [];
-		this.endingCell = null;
 		this.backgroundLength = [];
 
 		this.addPage(pageSize);
@@ -38,7 +37,6 @@ class DocumentContext extends EventEmitter {
 				availableWidth: this.availableWidth,
 				page: this.page
 			},
-			endingCell: this.endingCell,
 			lastColumnWidth: this.lastColumnWidth
 		});
 
@@ -48,9 +46,8 @@ class DocumentContext extends EventEmitter {
 	beginColumn(width, offset, endingCell) {
 		let saved = this.snapshots[this.snapshots.length - 1];
 
-		this.calculateBottomMost(saved);
+		this.calculateBottomMost(saved, endingCell);
 
-		this.endingCell = endingCell;
 		this.page = saved.page;
 		this.x = this.x + this.lastColumnWidth + (offset || 0);
 		this.y = saved.y;
@@ -60,10 +57,9 @@ class DocumentContext extends EventEmitter {
 		this.lastColumnWidth = width;
 	}
 
-	calculateBottomMost(destContext) {
-		if (this.endingCell) {
-			this.saveContextInEndingCell(this.endingCell);
-			this.endingCell = null;
+	calculateBottomMost(destContext, endingCell) {
+		if (endingCell) {
+			this.saveContextInEndingCell(endingCell);
 		} else {
 			destContext.bottomMost = bottomMostContext(this, destContext.bottomMost);
 		}
@@ -89,12 +85,11 @@ class DocumentContext extends EventEmitter {
 		};
 	}
 
-	completeColumnGroup(height) {
+	completeColumnGroup(height, endingCell) {
 		let saved = this.snapshots.pop();
 
-		this.calculateBottomMost(saved);
+		this.calculateBottomMost(saved, endingCell);
 
-		this.endingCell = null;
 		this.x = saved.x;
 
 		let y = saved.bottomMost.y;
@@ -171,7 +166,6 @@ class DocumentContext extends EventEmitter {
 			availableHeight: this.availableHeight,
 			availableWidth: this.availableWidth,
 			page: this.page,
-			endingCell: this.endingCell,
 			lastColumnWidth: this.lastColumnWidth
 		});
 	}
@@ -184,7 +178,6 @@ class DocumentContext extends EventEmitter {
 		this.availableWidth = saved.availableWidth;
 		this.availableHeight = saved.availableHeight;
 		this.page = saved.page;
-		this.endingCell = saved.endingCell;
 		this.lastColumnWidth = saved.lastColumnWidth;
 	}
 

--- a/tests/unit/DocumentContext.spec.js
+++ b/tests/unit/DocumentContext.spec.js
@@ -71,11 +71,10 @@ describe('DocumentContext', function () {
 		it('should save context in endingCell if provided', function () {
 			var endingCell = {};
 			pc.beginColumnGroup();
-			pc.beginColumn(30, 0, endingCell);
 			pc.y = 150;
 			pc.page = 3;
 			pc.availableHeight = 123;
-			pc.beginColumn(30, 0);
+			pc.beginColumn(30, 0, endingCell);
 
 			assert.equal(endingCell._columnEndingContext.y, 150);
 			assert.equal(endingCell._columnEndingContext.page, 3);
@@ -109,10 +108,10 @@ describe('DocumentContext', function () {
 			var endingCell = {};
 
 			pc.beginColumnGroup();
-			pc.beginColumn(30, 0, endingCell);
 			pc.y = 150;
 			pc.page = 3;
 			pc.availableHeight = 123;
+			pc.beginColumn(30, 0, endingCell);
 			pc.beginColumn(30, 0);
 			pc.y = 100;
 			pc.page = 3;
@@ -131,6 +130,7 @@ describe('DocumentContext', function () {
 			// col1 spans over 2 rows
 			pc.beginColumn(30, 0, endingCell);
 			pc.y = 350;
+			// col 2
 			pc.beginColumn(40);
 			pc.y = 100;
 			// column3 contains a nested table
@@ -147,7 +147,9 @@ describe('DocumentContext', function () {
 			pc.completeColumnGroup();
 
 			//// bottom of all non-spanned columns
-			assert.equal(pc.y, 120);
+			assert.equal(pc.y, 180);
+			// Check context has been stored in ending cell
+			assert.equal(endingCell2._columnEndingContext.y, 120);
 
 			// second row (of nested table)
 			pc.beginColumnGroup();
@@ -165,7 +167,7 @@ describe('DocumentContext', function () {
 			pc.completeColumnGroup();
 
 			//// bottom of all non-spanned columns
-			assert.equal(pc.y, 180);
+			assert.equal(pc.y, 350);
 
 			// second row
 			pc.beginColumnGroup();


### PR DESCRIPTION
Fixes all the issues below, it is just one bug though. The problem was that it was not storing the correct context in the ending cell of a row span when there were nested column groups (columns or tables). Now the reference to the ending cell is not stored in the DocumentContext but in the first cell that started the row span, this way we can after check if the current cell is just the cell after a row span and thus store the current context in the ending cell.
 
[#2069](https://github.com/bpampuch/pdfmake/issues/2069)
[#2189](https://github.com/bpampuch/pdfmake/issues/2189)
[#1545](https://github.com/bpampuch/pdfmake/issues/1545)
[#668](https://github.com/bpampuch/pdfmake/issues/668)
[#997](https://github.com/bpampuch/pdfmake/issues/997)
[#1654](https://github.com/bpampuch/pdfmake/issues/1654)