### PR TITLE
Fixes issue 1836

### DIFF
--- a/src/ElementWriter.js
+++ b/src/ElementWriter.js
@@ -322,10 +322,21 @@ class ElementWriter extends EventEmitter {
 					var v = pack(item.item);
 
 					offsetVector(v, useBlockXOffset ? (block.xOffset || 0) : ctx.x, useBlockYOffset ? (block.yOffset || 0) : ctx.y);
-					page.items.push({
-						type: 'vector',
-						item: v
-					});
+					if (v._isFillColorFromUnbreakable) {
+						// If the item is a fillColor from an unbreakable block
+						// We have to add it at the beginning of the items body array of the page
+						delete v._isFillColorFromUnbreakable;
+						const endOfBackgroundItemsIndex = ctx.backgroundLength[ctx.page];
+						page.items.splice(endOfBackgroundItemsIndex, 0, {
+							type: 'vector',
+							item: v
+						});
+					} else {
+						page.items.push({
+							type: 'vector',
+							item: v
+						});
+					}
 					break;
 
 				case 'image':

--- a/src/TableProcessor.js
+++ b/src/TableProcessor.js
@@ -490,7 +490,9 @@ class TableProcessor {
 								h: bgHeight,
 								lineWidth: 0,
 								color: fillColor,
-								fillOpacity: fillOpacity
+								fillOpacity: fillOpacity,
+								// mark if we are in an unbreakable block
+								_isFillColorFromUnbreakable: !!writer.transactionLevel
 							}, false, true, writer.context().backgroundLength[writer.context().page]);
 						}
 


### PR DESCRIPTION
Fixes issue [#1836](https://github.com/bpampuch/pdfmake/issues/1836)

The problem was that fillColor items of unbreakable blocks were not being added at the beginning of the body items array like any other fillColor items.