### PR TITLE
Fixes issues #1006 and #2748

### DIFF
--- a/tests/unit/LayoutBuilder.spec.js
+++ b/tests/unit/LayoutBuilder.spec.js
@@ -1679,7 +1679,13 @@ describe('LayoutBuilder', function () {
 		it('should return an empty array if no page breaks occur', function () {
 			var doc = createTable(1, 0);
 
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 
 			assert(result.pageBreaks instanceof Array);
 			assert.equal(result.pageBreaks.length, 0);
@@ -1687,8 +1693,13 @@ describe('LayoutBuilder', function () {
 
 		it('on page break should return an entry with ending/starting positions', function () {
 			var doc = createTable(0, 1, 10, 5, 5);
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
-
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 			assert(result.pageBreaks instanceof Array);
 			assert.equal(result.pageBreaks.length, 1);
 			assert.equal(result.pageBreaks[0].prevPage, 0);
@@ -1697,7 +1708,13 @@ describe('LayoutBuilder', function () {
 
 		it('on page break should return an entry with ending/starting positions 2', function () {
 			var doc = createTable(0, 1, 10, 5);
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 
 			assert(result.pageBreaks instanceof Array);
 			assert.equal(result.pageBreaks.length, 1);
@@ -1708,14 +1725,26 @@ describe('LayoutBuilder', function () {
 
 		it('on multi-pass page break (columns or table columns) should treat bottom-most page-break as the ending position ', function () {
 			var doc = createTable(0, 1, 10, 5, 7);
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 
 			assert.equal(result.pageBreaks[0].prevY, 40 + 12 * 7);
 		});
 
 		it('on multiple page breaks (more than 2 pages), should return all entries with ending/starting positions', function () {
 			var doc = createTable(0, 1, 100, 90, 90);
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 
 			assert(result.pageBreaks instanceof Array);
 			assert.equal(result.pageBreaks.length, 2);
@@ -1727,7 +1756,13 @@ describe('LayoutBuilder', function () {
 
 		it('on multiple page breaks (more than 2 pages), should return all entries with ending/starting positions 2', function () {
 			var doc = createTable(0, 1, 100, 90);
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 
 			assert(result.pageBreaks instanceof Array);
 			assert.equal(result.pageBreaks.length, 2);
@@ -1739,7 +1774,13 @@ describe('LayoutBuilder', function () {
 
 		it('on multiple and multi-pass page breaks should calculate bottom-most endings for every page', function () {
 			var doc = createTable(0, 1, 100, 90, 92);
-			var result = builder2.processRow(false, doc.table.body[0], doc.table.widths, doc._offsets.offsets, doc.table.body, 0);
+			var result = builder2.processRow({
+				cells: doc.table.body[0],
+				widths: doc.table.widths,
+				gaps: doc._offsets.offsets,
+				tableBody: doc.table.body,
+				rowIndex: 0
+			});
 
 			assert(result.pageBreaks instanceof Array);
 			assert.equal(result.pageBreaks.length, 2);


### PR DESCRIPTION
Fixes issues [#1006](https://github.com/bpampuch/pdfmake/issues/1006) and [#2748](https://github.com/bpampuch/pdfmake/issues/2748)

Now margins (top/bottom) of nodes and row height are considered for breaking page