### PR TITLE
Fixess issues 995 and 2490

### DIFF
--- a/src/ElementWriter.js
+++ b/src/ElementWriter.js
@@ -259,9 +259,12 @@ class ElementWriter extends EventEmitter {
 		}
 	}
 
-	addVector(vector, ignoreContextX, ignoreContextY, index) {
+	addVector(vector, ignoreContextX, ignoreContextY, index, forcePage) {
 		let context = this.context();
 		let page = context.getCurrentPage();
+		if (isNumber(forcePage)) {
+			page = context.pages[forcePage];
+		}
 		let position = this.getCurrentPositionOnPage();
 
 		if (page) {

--- a/src/PageElementWriter.js
+++ b/src/PageElementWriter.js
@@ -39,8 +39,8 @@ class PageElementWriter extends ElementWriter {
 		return this._fitOnPage(() => super.addAttachment(attachment, index));
 	}
 
-	addVector(vector, ignoreContextX, ignoreContextY, index) {
-		return super.addVector(vector, ignoreContextX, ignoreContextY, index);
+	addVector(vector, ignoreContextX, ignoreContextY, index, forcePage) {
+		return super.addVector(vector, ignoreContextX, ignoreContextY, index, forcePage);
 	}
 
 	beginClip(width, height) {


### PR DESCRIPTION
Fixes issues [#995](https://github.com/bpampuch/pdfmake/issues/995) and [#2490](https://github.com/bpampuch/pdfmake/issues/2490). They are both related to the drawing of the top border horizontal line of a table.

- The problem with [#995](https://github.com/bpampuch/pdfmake/issues/995) was that the top horizontal line of the table was drawn before the `beginUnbreakableBlock` of the `dontBreakRows` property was executed, leaving the horizontal line orphan in case of a pabe break. This bug appeared when `dontBreakRows` is active, table has no `headerRows`, and first row of the table causes a page break.
- The problem with [#2490](https://github.com/bpampuch/pdfmake/issues/2490) was that it was drawing the top border of  a table with no `headersRow` and no `dontBreakRows` before knowing if the flag `skipOrphanePadding` will be activated. `skipOrphanePadding` causes not to draw any piece of a row in the current page. That is why the drawing of the table top border of the table when it has no `headerRows` and no `dontBreakRows`, has been moved to the method `endRow`, where we know if `skipOrphanePadding` will be activated or not. 