### PR TITLE
remove brfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@eslint/js": "^9.14.0",
     "assert": "^2.1.0",
     "babel-loader": "^9.2.1",
-    "brfs": "^2.0.2",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "core-js": "3.19.0",


### PR DESCRIPTION
Hi, here's a small PR to remove brfs package. It has es5-ext in its dependencies, which is detected as malicious software by various scanners and many people need to deal with it in their organisations one way or another.

In #2701 you said brfs is not used in any way. I made a fork of your repo, removed brfs, published to npm and installed it in app in our organisation and things seem to work fine so far