### PR TITLE
Fix dontBreakRows rowSpan ending offset across pages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 	```
 - Fixed extra blank page when using headerRows, dontBreakRows and cell pageBreak together
 - Fixed rendering of an invalid color name - previously it used the last valid color; now it defaults to black
+- Fixed dontBreakRows rowSpan ending offset across pages
 
 ## 0.3.7 - 2026-03-17
 

--- a/src/LayoutBuilder.js
+++ b/src/LayoutBuilder.js
@@ -942,11 +942,13 @@ class LayoutBuilder {
 				// We store a reference of the ending cell in the first cell of the rowspan
 				cell._endingCell = rowSpanRightEndingCell;
 				cell._endingCell._startingRowSpanY = cell._startingRowSpanY;
+				cell._endingCell._startingRowSpanPage = cell._startingRowSpanPage;
 			}
 			if (rowSpanLeftEndingCell) {
 				// We store a reference of the left ending cell in the first cell of the rowspan
 				cell._leftEndingCell = rowSpanLeftEndingCell;
 				cell._leftEndingCell._startingRowSpanY = cell._startingRowSpanY;
+				cell._leftEndingCell._startingRowSpanPage = cell._startingRowSpanPage;
 			}
 
 			// If we are after a cell that started a rowspan
@@ -984,7 +986,17 @@ class LayoutBuilder {
 				if (dontBreakRows) {
 					// Calculate how many points we have to discount to Y when dontBreakRows and rowSpan are combined
 					const ctxBeforeRowSpanLastRow = this.writer.contextStack[this.writer.contextStack.length - 1];
-					discountY = ctxBeforeRowSpanLastRow.y - cell._startingRowSpanY;
+					const startsOnCurrentPage = (
+						typeof cell._startingRowSpanPage === 'number' &&
+						cell._startingRowSpanPage === ctxBeforeRowSpanLastRow.page
+					);
+
+					if (startsOnCurrentPage && typeof cell._startingRowSpanY === 'number') {
+						discountY = ctxBeforeRowSpanLastRow.y - cell._startingRowSpanY;
+					}
+
+					// Do not increase Y by applying a negative discount.
+					discountY = Math.max(0, discountY);
 				}
 				let originalXOffset = 0;
 				// If context was saved from an unbreakable block and we are not in an unbreakable block anymore
@@ -1170,6 +1182,7 @@ class LayoutBuilder {
 				tableNode.table.body[i].forEach(cell => {
 					if (cell.rowSpan && cell.rowSpan > 1) {
 						cell._startingRowSpanY = this.writer.context().y;
+						cell._startingRowSpanPage = this.writer.context().page;
 					}
 				});
 			}

--- a/tests/integration/tables.spec.js
+++ b/tests/integration/tables.spec.js
@@ -338,4 +338,68 @@ describe('Integration test: tables', function () {
 		});
 	});
 
+	it('keeps row heights stable when rowSpan crosses pages with dontBreakRows (#2895)', function () {
+		var dd = {
+			content: {
+				table: {
+					dontBreakRows: true,
+					heights: 45,
+					widths: [50, 100, 200, 50],
+					body: [
+						['1', '2', '3', '4'],
+						[{ rowSpan: 4, text: '4span' }, null, null, null],
+						[null, null, null, null],
+						[{ rowSpan: 2, text: '2span' }, null, null, null],
+						[null, null, null, null],
+						[{ rowSpan: 2, text: null }, null, null, null],
+						[null, null, null, null],
+						[{ rowSpan: 2, text: null }, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[{ rowSpan: 15, text: 'span 15', maxHeight: 50 }, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null],
+						[{ rowSpan: 5, text: 'span 5' }, null, null, null],
+						[null, null, null, null],
+						[{ rowSpan: 2, text: null }, null, null, null],
+						[null, null, null, null],
+						[null, null, null, null]
+					]
+				}
+			}
+		};
+
+		var pages = testHelper.renderPages('A4', dd);
+		var lastPage = pages[pages.length - 1];
+		var horizontalLineYs = [...new Set(
+			lastPage.items
+				.filter(node => node.type === 'vector' && node.item.type === 'line' && Math.abs(node.item.y1 - node.item.y2) < 0.001)
+				.map(node => Number(node.item.y1.toFixed(3)))
+		)].sort((a, b) => a - b);
+
+		var maxGap = 0;
+		for (var i = 1; i < horizontalLineYs.length; i++) {
+			maxGap = Math.max(maxGap, horizontalLineYs[i] - horizontalLineYs[i - 1]);
+		}
+
+		// Each row is 45pt tall. A gap above ~90pt would indicate a blown-out row caused
+		// by a negative discountY when a rowspan started on a previous page. Allow up to
+		// 2x row height (90pt) as a safe upper bound; anything beyond that is the bug.
+		assert.ok(maxGap < 90, 'max gap between horizontal lines was ' + maxGap + 'pt, expected < 90pt');
+	});
+
 });


### PR DESCRIPTION
Fixes #2895 
## Summary
  When `dontBreakRows` is enabled and a `rowSpan` crosses pages, the row-span ending context could apply a negative Y discount. That  moved the cursor too far down and created an oversized last row.

  ## Changes
  - Track the page where a rowSpan starts.
  - Apply row-span `discountY` only when the start page matches the current page.
  - Clamp `discountY` to `>= 0`.
  - Add integration regression test:
  - `keeps row heights stable when rowSpan crosses pages with dontBreakRows (#2895)`