### PR TITLE
Add page rotation support

### DIFF
--- a/src/DocumentContext.js
+++ b/src/DocumentContext.js
@@ -447,7 +447,7 @@ class DocumentContext extends EventEmitter {
 		this.lastColumnWidth = saved.lastColumnWidth;
 	}
 
-	moveToNextPage(pageOrientation, pageFlip, pageRotation) {
+	moveToNextPage(pageOrientation, pageRotation) {
 		let nextPageIndex = this.page + 1;
 		let prevPage = this.page;
 		let prevY = this.y;
@@ -469,7 +469,7 @@ class DocumentContext extends EventEmitter {
 
 			let pageSize = getPageSize(this.getCurrentPage(), pageOrientation);
 
-			this.addPage(pageSize, null, this.getCurrentPage().customProperties, pageFlip, pageRotation);
+			this.addPage(pageSize, null, this.getCurrentPage().customProperties, pageRotation);
 
 			if (currentPageOrientation === pageSize.orientation) {
 				this.availableWidth = currentAvailableWidth;
@@ -487,14 +487,14 @@ class DocumentContext extends EventEmitter {
 		};
 	}
 
-	addPage(pageSize, pageMargin = null, customProperties = {}, pageFlip = {}, pageRotation = undefined) {
+	addPage(pageSize, pageMargin = null, customProperties = {}, pageRotation = undefined) {
 		if (pageMargin !== null) {
 			this.pageMargins = pageMargin;
 			this.x = pageMargin.left;
 			this.availableWidth = pageSize.width - pageMargin.left - pageMargin.right;
 		}
 
-		let page = { items: [], pageSize: pageSize, pageMargins: this.pageMargins, customProperties: customProperties, pageFlip, pageRotation };
+		let page = { items: [], pageSize: pageSize, pageMargins: this.pageMargins, customProperties: customProperties, pageRotation };
 		this.pages.push(page);
 		this.backgroundLength.push(0);
 		this.page = this.pages.length - 1;

--- a/src/DocumentContext.js
+++ b/src/DocumentContext.js
@@ -447,7 +447,7 @@ class DocumentContext extends EventEmitter {
 		this.lastColumnWidth = saved.lastColumnWidth;
 	}
 
-	moveToNextPage(pageOrientation) {
+	moveToNextPage(pageOrientation, pageFlip, pageRotation) {
 		let nextPageIndex = this.page + 1;
 		let prevPage = this.page;
 		let prevY = this.y;
@@ -468,7 +468,8 @@ class DocumentContext extends EventEmitter {
 			let currentPageOrientation = this.getCurrentPage().pageSize.orientation;
 
 			let pageSize = getPageSize(this.getCurrentPage(), pageOrientation);
-			this.addPage(pageSize, null, this.getCurrentPage().customProperties);
+
+			this.addPage(pageSize, null, this.getCurrentPage().customProperties, pageFlip, pageRotation);
 
 			if (currentPageOrientation === pageSize.orientation) {
 				this.availableWidth = currentAvailableWidth;
@@ -486,14 +487,14 @@ class DocumentContext extends EventEmitter {
 		};
 	}
 
-	addPage(pageSize, pageMargin = null, customProperties = {}) {
+	addPage(pageSize, pageMargin = null, customProperties = {}, pageFlip = {}, pageRotation = undefined) {
 		if (pageMargin !== null) {
 			this.pageMargins = pageMargin;
 			this.x = pageMargin.left;
 			this.availableWidth = pageSize.width - pageMargin.left - pageMargin.right;
 		}
 
-		let page = { items: [], pageSize: pageSize, pageMargins: this.pageMargins, customProperties: customProperties };
+		let page = { items: [], pageSize: pageSize, pageMargins: this.pageMargins, customProperties: customProperties, pageFlip, pageRotation };
 		this.pages.push(page);
 		this.backgroundLength.push(0);
 		this.page = this.pages.length - 1;

--- a/src/LayoutBuilder.js
+++ b/src/LayoutBuilder.js
@@ -53,6 +53,7 @@ class LayoutBuilder {
 	 * @param {object} footer
 	 * @param {object} watermark
 	 * @param {object} pageBreakBeforeFct
+	 * @param {number} pageRotation
 	 * @returns {Array} an array of pages
 	 */
 	layoutDocument(
@@ -64,7 +65,8 @@ class LayoutBuilder {
 		header,
 		footer,
 		watermark,
-		pageBreakBeforeFct
+		pageBreakBeforeFct,
+		pageRotation
 	) {
 
 		function addPageBreaksIfNecessary(linearNodeList, pages) {
@@ -159,10 +161,10 @@ class LayoutBuilder {
 			});
 		}
 
-		let result = this.tryLayoutDocument(docStructure, pdfDocument, styleDictionary, defaultStyle, background, header, footer, watermark);
+		let result = this.tryLayoutDocument(docStructure, pdfDocument, styleDictionary, defaultStyle, background, header, footer, watermark, pageRotation);
 		while (addPageBreaksIfNecessary(result.linearNodeList, result.pages)) {
 			resetXYs(result);
-			result = this.tryLayoutDocument(docStructure, pdfDocument, styleDictionary, defaultStyle, background, header, footer, watermark);
+			result = this.tryLayoutDocument(docStructure, pdfDocument, styleDictionary, defaultStyle, background, header, footer, watermark, pageRotation);
 		}
 
 		return result.pages;
@@ -176,7 +178,8 @@ class LayoutBuilder {
 		background,
 		header,
 		footer,
-		watermark
+		watermark,
+		pageRotation
 	) {
 
 		const isNecessaryAddFirstPage = (docStructure) => {
@@ -193,7 +196,7 @@ class LayoutBuilder {
 		docStructure = this.docPreprocessor.preprocessDocument(docStructure);
 		docStructure = this.docMeasure.measureDocument(docStructure);
 
-		this.writer = new PageElementWriter(new DocumentContext());
+		this.writer = new PageElementWriter(new DocumentContext(), pageRotation);
 
 		this.writer.context().addListener('pageAdded', (page) => {
 			let backgroundGetter = background;
@@ -208,7 +211,9 @@ class LayoutBuilder {
 			this.writer.addPage(
 				this.pageSize,
 				null,
-				this.pageMargins
+				this.pageMargins,
+				{},
+				pageRotation
 			);
 		}
 
@@ -397,16 +402,16 @@ class LayoutBuilder {
 			let margin = node._margin;
 
 			if (node.pageBreak === 'before') {
-				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 			} else if (node.pageBreak === 'beforeOdd') {
-				this.writer.moveToNextPage(node.pageOrientation,node.pageFlip, node.pageRotation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 1) {
-					this.writer.moveToNextPage(node.pageOrientation,node.pageFlip, node.pageRotation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				}
 			} else if (node.pageBreak === 'beforeEven') {
-				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 0) {
-					this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				}
 			}
 
@@ -421,9 +426,9 @@ class LayoutBuilder {
 					// Consume the whole available space
 					this.writer.context().moveDown(availableHeight);
 					if (this.writer.context().inSnakingColumns() && !this.writer.context().isInNestedNonSnakingGroup()) {
-						this.snakingAwarePageBreak(node.pageOrientation);
+						this.snakingAwarePageBreak(node.pageOrientation, node.pageRotation);
 					} else {
-						this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+						this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 					}
 					/**
 					 * TODO - Something to consider:
@@ -447,9 +452,9 @@ class LayoutBuilder {
 				if (availableHeight - margin[3] < 0) {
 					this.writer.context().moveDown(availableHeight);
 					if (this.writer.context().inSnakingColumns() && !this.writer.context().isInNestedNonSnakingGroup()) {
-						this.snakingAwarePageBreak(node.pageOrientation);
+						this.snakingAwarePageBreak(node.pageOrientation, node.pageRotation);
 					} else {
-						this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+						this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 					}
 					/**
 					 * TODO - Something to consider:
@@ -465,16 +470,16 @@ class LayoutBuilder {
 			}
 
 			if (node.pageBreak === 'after') {
-				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 			} else if (node.pageBreak === 'afterOdd') {
-				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 1) {
-					this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				}
 			} else if (node.pageBreak === 'afterEven') {
-				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 0) {
-					this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageRotation);
 				}
 			}
 		};
@@ -566,9 +571,9 @@ class LayoutBuilder {
 	 * When in snaking columns, first tries moving to next column.
 	 * If no columns available, moves to next page and resets x to left margin.
 	 * @param {string} pageOrientation - Optional page orientation for the new page
-	 * @param {string} pageFlip - Optional page flip for the new page
+	 * @param {string} pageRotation - Optional page rotation for the new page
 	 */
-	snakingAwarePageBreak(pageOrientation, pageFlip) {
+	snakingAwarePageBreak(pageOrientation, pageRotation) {
 		let ctx = this.writer.context();
 		let snakingSnapshot = ctx.getSnakingSnapshot();
 		if (!snakingSnapshot) {
@@ -582,7 +587,7 @@ class LayoutBuilder {
 		}
 
 		// No more columns available, move to new page
-		this.writer.moveToNextPage(pageOrientation, pageFlip);
+		this.writer.moveToNextPage(pageOrientation, pageRotation);
 
 		// Reset snaking column state for the new page
 		// Save lastColumnWidth before reset — if we're inside a nested
@@ -665,7 +670,8 @@ class LayoutBuilder {
 				sectionNode.pageSize || this.pageSize,
 				sectionNode.pageOrientation,
 				sectionNode.pageMargins || this.pageMargins,
-				customProperties
+				customProperties,
+				sectionNode.pageRotation
 			);
 		}
 
@@ -1041,7 +1047,7 @@ class LayoutBuilder {
 			if (snakingColumns) {
 				this.snakingAwarePageBreak();
 			} else {
-				this.writer.moveToNextPage();
+				this.writer.moveToNextPage(undefined, this.pageRotation);
 			}
 		}
 
@@ -1321,7 +1327,7 @@ class LayoutBuilder {
 					line = this.buildNextLine(node);
 					continue;
 				} else {
-					this.writer.moveToNextPage(node.pageOrientation);
+					this.writer.moveToNextPage(node.pageOrientation, this.pageRotation);
 				}
 			}
 

--- a/src/LayoutBuilder.js
+++ b/src/LayoutBuilder.js
@@ -397,16 +397,16 @@ class LayoutBuilder {
 			let margin = node._margin;
 
 			if (node.pageBreak === 'before') {
-				this.writer.moveToNextPage(node.pageOrientation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 			} else if (node.pageBreak === 'beforeOdd') {
-				this.writer.moveToNextPage(node.pageOrientation);
+				this.writer.moveToNextPage(node.pageOrientation,node.pageFlip, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 1) {
-					this.writer.moveToNextPage(node.pageOrientation);
+					this.writer.moveToNextPage(node.pageOrientation,node.pageFlip, node.pageRotation);
 				}
 			} else if (node.pageBreak === 'beforeEven') {
-				this.writer.moveToNextPage(node.pageOrientation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 0) {
-					this.writer.moveToNextPage(node.pageOrientation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 				}
 			}
 
@@ -423,7 +423,7 @@ class LayoutBuilder {
 					if (this.writer.context().inSnakingColumns() && !this.writer.context().isInNestedNonSnakingGroup()) {
 						this.snakingAwarePageBreak(node.pageOrientation);
 					} else {
-						this.writer.moveToNextPage(node.pageOrientation);
+						this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 					}
 					/**
 					 * TODO - Something to consider:
@@ -449,7 +449,7 @@ class LayoutBuilder {
 					if (this.writer.context().inSnakingColumns() && !this.writer.context().isInNestedNonSnakingGroup()) {
 						this.snakingAwarePageBreak(node.pageOrientation);
 					} else {
-						this.writer.moveToNextPage(node.pageOrientation);
+						this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 					}
 					/**
 					 * TODO - Something to consider:
@@ -465,16 +465,16 @@ class LayoutBuilder {
 			}
 
 			if (node.pageBreak === 'after') {
-				this.writer.moveToNextPage(node.pageOrientation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 			} else if (node.pageBreak === 'afterOdd') {
-				this.writer.moveToNextPage(node.pageOrientation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 1) {
-					this.writer.moveToNextPage(node.pageOrientation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 				}
 			} else if (node.pageBreak === 'afterEven') {
-				this.writer.moveToNextPage(node.pageOrientation);
+				this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 				if ((this.writer.context().page + 1) % 2 === 0) {
-					this.writer.moveToNextPage(node.pageOrientation);
+					this.writer.moveToNextPage(node.pageOrientation, node.pageFlip, node.pageRotation);
 				}
 			}
 		};
@@ -566,8 +566,9 @@ class LayoutBuilder {
 	 * When in snaking columns, first tries moving to next column.
 	 * If no columns available, moves to next page and resets x to left margin.
 	 * @param {string} pageOrientation - Optional page orientation for the new page
+	 * @param {string} pageFlip - Optional page flip for the new page
 	 */
-	snakingAwarePageBreak(pageOrientation) {
+	snakingAwarePageBreak(pageOrientation, pageFlip) {
 		let ctx = this.writer.context();
 		let snakingSnapshot = ctx.getSnakingSnapshot();
 		if (!snakingSnapshot) {
@@ -581,7 +582,7 @@ class LayoutBuilder {
 		}
 
 		// No more columns available, move to new page
-		this.writer.moveToNextPage(pageOrientation);
+		this.writer.moveToNextPage(pageOrientation, pageFlip);
 
 		// Reset snaking column state for the new page
 		// Save lastColumnWidth before reset — if we're inside a nested

--- a/src/PageElementWriter.js
+++ b/src/PageElementWriter.js
@@ -14,9 +14,11 @@ class PageElementWriter extends ElementWriter {
 
 	/**
 	 * @param {DocumentContext} context
+	 * @param {number} pageRotation
 	 */
-	constructor(context) {
+	constructor(context, pageRotation) {
 		super(context);
+		this.pageRotation = pageRotation;
 		this.transactionLevel = 0;
 		this.repeatables = [];
 	}
@@ -69,8 +71,8 @@ class PageElementWriter extends ElementWriter {
 		return this._fitOnPage(() => super.addFragment(fragment, useBlockXOffset, useBlockYOffset, dontUpdateContextPosition));
 	}
 
-	moveToNextPage(pageOrientation, pageFlip, pageRotation) {
-		let nextPage = this.context().moveToNextPage(pageOrientation, pageFlip, pageRotation);
+	moveToNextPage(pageOrientation, pageRotation) {
+		let nextPage = this.context().moveToNextPage(pageOrientation, pageRotation ?? this.pageRotation);
 
 		// moveToNextPage is called multiple times for table, because is called for each column
 		// and repeatables are inserted only in the first time. If columns are used, is needed
@@ -91,11 +93,11 @@ class PageElementWriter extends ElementWriter {
 		});
 	}
 
-	addPage(pageSize, pageOrientation, pageMargin, customProperties = {}) {
+	addPage(pageSize, pageOrientation, pageMargin, customProperties = {}, pageRotation = undefined) {
 		let prevPage = this.page;
 		let prevY = this.y;
 
-		this.context().addPage(normalizePageSize(pageSize, pageOrientation), normalizePageMargin(pageMargin), customProperties);
+		this.context().addPage(normalizePageSize(pageSize, pageOrientation), normalizePageMargin(pageMargin), customProperties, pageRotation ?? this.pageRotation);
 
 		this.emit('pageChanged', {
 			prevPage: prevPage,

--- a/src/PageElementWriter.js
+++ b/src/PageElementWriter.js
@@ -69,8 +69,8 @@ class PageElementWriter extends ElementWriter {
 		return this._fitOnPage(() => super.addFragment(fragment, useBlockXOffset, useBlockYOffset, dontUpdateContextPosition));
 	}
 
-	moveToNextPage(pageOrientation) {
-		let nextPage = this.context().moveToNextPage(pageOrientation);
+	moveToNextPage(pageOrientation, pageFlip, pageRotation) {
+		let nextPage = this.context().moveToNextPage(pageOrientation, pageFlip, pageRotation);
 
 		// moveToNextPage is called multiple times for table, because is called for each column
 		// and repeatables are inserted only in the first time. If columns are used, is needed

--- a/src/Printer.js
+++ b/src/Printer.js
@@ -81,7 +81,7 @@ class PdfPrinter {
 			builder.registerTableLayouts(options.tableLayouts);
 		}
 
-		let pages = builder.layoutDocument(docDefinition.content, this.pdfKitDoc, docDefinition.styles || {}, docDefinition.defaultStyle || { fontSize: 12, font: 'Roboto' }, docDefinition.background, docDefinition.header, docDefinition.footer, docDefinition.watermark, docDefinition.pageBreakBefore);
+		let pages = builder.layoutDocument(docDefinition.content, this.pdfKitDoc, docDefinition.styles || {}, docDefinition.defaultStyle || { fontSize: 12, font: 'Roboto' }, docDefinition.background, docDefinition.header, docDefinition.footer, docDefinition.watermark, docDefinition.pageBreakBefore, docDefinition.pageRotation);
 		let maxNumberPages = docDefinition.maxPagesNumber || -1;
 		if (isNumber(maxNumberPages) && maxNumberPages > -1) {
 			pages = pages.slice(0, maxNumberPages);

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -64,7 +64,7 @@ class Renderer {
 				this.pdfDocument.addPage({ size: [pages[i].pageSize.width, pages[i].pageSize.height] });
 			}
 			let page = pages[i];
-			let flipped = this.applyPageFlip(page);
+			let pageStateSaved = this.applyPageRotation(page);
 			for (let ii = 0, il = page.items.length; ii < il; ii++) {
 				let item = page.items[ii];
 				switch (item.type) {
@@ -104,7 +104,7 @@ class Renderer {
 			if (page.watermark) {
 				this.renderWatermark(page);
 			}
-			if(flipped){
+			if(pageStateSaved){
 				this.pdfDocument.restore();
 			}
 		}
@@ -441,10 +441,9 @@ class Renderer {
 		}
 	}
 
-	applyPageFlip(page) {
-		const flip = page.pageFlip;
+	applyPageRotation(page) {
 		const rotation = page.pageRotation;
-		if (!flip && rotation === undefined) {
+		if (rotation === undefined) {
 			return false;
 		}
 
@@ -468,21 +467,6 @@ class Renderer {
 				this.pdfDocument.rotate(270);
 				this.pdfDocument.translate(-width, 0);
 				break;
-		}
-
-		if(flip?.vertical){
-			this.pdfDocument.transform(
-				1, 0,
-				0, -1,
-				0, height
-			);
-		}
-		if(flip?.horizontal){
-			this.pdfDocument.transform(
-				-1, 0,
-				0, 1,
-				width, 0
-			);
 		}
 
 		return true;

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -57,9 +57,14 @@ class Renderer {
 		let renderedItems = 0;
 
 		for (let i = 0; i < pages.length; i++) {
-			this.pdfDocument.addPage({ size: [pages[i].pageSize.width, pages[i].pageSize.height] });
-
+			if(pages[i].pageRotation === 90 || pages[i].pageRotation === 270){
+				this.pdfDocument.addPage({ size: [pages[i].pageSize.height, pages[i].pageSize.width] });
+			}
+			else{
+				this.pdfDocument.addPage({ size: [pages[i].pageSize.width, pages[i].pageSize.height] });
+			}
 			let page = pages[i];
+			let flipped = this.applyPageFlip(page);
 			for (let ii = 0, il = page.items.length; ii < il; ii++) {
 				let item = page.items[ii];
 				switch (item.type) {
@@ -98,6 +103,9 @@ class Renderer {
 			}
 			if (page.watermark) {
 				this.renderWatermark(page);
+			}
+			if(flipped){
+				this.pdfDocument.restore();
 			}
 		}
 	}
@@ -431,6 +439,53 @@ class Renderer {
 				this.pdfDocument.restore();
 				break;
 		}
+	}
+
+	applyPageFlip(page) {
+		const flip = page.pageFlip;
+		const rotation = page.pageRotation;
+		if (!flip && rotation === undefined) {
+			return false;
+		}
+
+		const width = page.pageSize.width;
+		const height = page.pageSize.height;
+
+		this.pdfDocument.save();
+
+		switch (rotation) {
+			case 90:
+				this.pdfDocument.rotate(90);
+				this.pdfDocument.translate(0, -height);
+				break;
+
+			case 180:
+				this.pdfDocument.rotate(180);
+				this.pdfDocument.translate(-width, -height);
+				break;
+
+			case 270:
+				this.pdfDocument.rotate(270);
+				this.pdfDocument.translate(-width, 0);
+				break;
+		}
+
+		if(flip?.vertical){
+			this.pdfDocument.transform(
+				1, 0,
+				0, -1,
+				0, height
+			);
+		}
+		if(flip?.horizontal){
+			this.pdfDocument.transform(
+				-1, 0,
+				0, 1,
+				width, 0
+			);
+		}
+
+		return true;
 	}
 
 	renderWatermark(page) {

--- a/tests/unit/LayoutBuilder.spec.js
+++ b/tests/unit/LayoutBuilder.spec.js
@@ -1289,6 +1289,104 @@ describe('LayoutBuilder', function () {
 			assert.equal(pages[2].pageSize.orientation, 'landscape');
 		});
 
+		it('should apply document page rotation to every page', function () {
+
+			var desc = [
+				{ text: 'Page 1' },
+				{ text: 'Page 2', pageBreak: 'before' }
+			];
+
+			var pages = builder.layoutDocument(
+				desc,
+				sampleTestProvider,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				90
+			);
+
+			assert.equal(pages.length, 2);
+			assert.equal(pages[0].pageRotation, 90);
+			assert.equal(pages[1].pageRotation, 90);
+		});
+
+		it('should allow a node to override document page rotation', function () {
+
+			var desc = [
+				{
+					text: 'Page 1'
+				},
+				{
+					text: 'Page 2',
+					pageBreak: 'before',
+					pageRotation: 180
+				},
+				{
+					text: 'Page 3',
+					pageBreak: 'before'
+				}
+			];
+			
+			var pages = builder.layoutDocument(
+				desc,
+				sampleTestProvider,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				90
+			);
+
+			assert.equal(pages.length, 3);
+			assert.equal(pages[0].pageRotation, 90);
+			assert.equal(pages[1].pageRotation, 180);
+			assert.equal(pages[2].pageRotation, 90);
+		});
+
+		it('should support page rotation on a node without a document rotation', function () {
+			var desc = [
+				{
+					text: 'Page 1'
+				},
+				{
+					text: 'Page 2',
+					pageBreak: 'before',
+					pageRotation: 270
+				}
+			];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 2);
+			assert.equal(pages[0].pageRotation, undefined);
+			assert.equal(pages[1].pageRotation, 270);
+		});
+
+		it('should leave page rotation undefined when no rotation is specified', function () {
+			var desc = [
+				{
+					text: 'Page 1'
+				},
+				{
+					text: 'Page 2',
+					pageBreak: 'before'
+				}
+			];
+
+			var pages = builder.layoutDocument(desc, sampleTestProvider);
+
+			assert.equal(pages.length, 2);
+			assert.equal(pages[0].pageRotation, undefined);
+			assert.equal(pages[1].pageRotation, undefined);
+		});
+
 		it('should use the absolutePosition attribute to position in absolute coordinates', function () {
 			var desc = [
 				{


### PR DESCRIPTION
### Summary

Adds support for page rotation in pdfmake.

### Changes

- Adds document-level pageRotation support.
- Allows individual nodes to override the document rotation.
- Propagates rotation when new pages are created, including automatic page breaks.
- Applies the rotation during PDF rendering.
- Adds tests for document-level rotation, node-level overrides, and automatic page creation.

### Usage

**Page rotation can be specified at the document level:**

```
var docDefinition = {
    pageRotation: 90,
    content: [
        {
            text: 'Page 1'
        },
        {
            text: 'Page 2',
            pageBreak: 'before'
        }
    ]
};
```

In this example, both pages are rotated 90 degrees.

**Individual nodes can override the document-level rotation:**

```
var docDefinition = {
    pageRotation: 90,
    content: [
        {
            text: 'Page 1 - 90 degrees'
        },
        {
            text: 'Page 2 - 180 degrees',
            pageBreak: 'before',
            pageRotation: 180
        },
        {
            text: 'Page 3 - 90 degrees',
            pageBreak: 'before'
        }
    ]
};
```

Here, pages 1 and 3 use the document-level rotation of 90 degrees, while page 2 overrides it with 180 degrees.

### Testing

Tested document rotation across multiple pages, node-level rotation overrides, and automatic page breaks. Existing tests also pass.