### PR TITLE
Fix reversed paint order of table cell fills in unbreakable blocks

### DIFF
--- a/src/ElementWriter.js
+++ b/src/ElementWriter.js
@@ -331,6 +331,8 @@ class ElementWriter extends EventEmitter {
 			return false;
 		}
 
+		let unbreakableFillsInserted = 0;
+
 		block.items.forEach(item => {
 			switch (item.type) {
 				case 'line':
@@ -354,9 +356,11 @@ class ElementWriter extends EventEmitter {
 					offsetVector(v, useBlockXOffset ? (block.xOffset || 0) : ctx.x, useBlockYOffset ? (block.yOffset || 0) : ctx.y);
 					if (v._isFillColorFromUnbreakable) {
 						// If the item is a fillColor from an unbreakable block
-						// We have to add it at the beginning of the items body array of the page
+						// We have to add it at the beginning of the items body array of the page,
+						// after the fills already inserted from this block so that they keep their draw order
 						delete v._isFillColorFromUnbreakable;
-						const endOfBackgroundItemsIndex = ctx.backgroundLength[ctx.page];
+						const endOfBackgroundItemsIndex = ctx.backgroundLength[ctx.page] + unbreakableFillsInserted;
+						unbreakableFillsInserted++;
 						page.items.splice(endOfBackgroundItemsIndex, 0, {
 							type: 'vector',
 							item: v

--- a/tests/unit/ElementWriter.spec.js
+++ b/tests/unit/ElementWriter.spec.js
@@ -237,5 +237,22 @@ describe('ElementWriter', function () {
 			assert.equal(fragment.items[3].item.x, 40);
 			assert.equal(fragment.items[3].item.y, 60);
 		});
+
+		it('should keep the draw order of fill colors from an unbreakable block', function () {
+			ctx.page = 0;
+			ctx.backgroundLength = [1];
+			page.items = [{ type: 'vector', item: { type: 'rect', color: 'pageBackground' } }];
+
+			fragment.items = [
+				{ type: 'vector', item: { type: 'rect', color: 'firstFill', _isFillColorFromUnbreakable: true } },
+				{ type: 'vector', item: { type: 'rect', color: 'secondFill', _isFillColorFromUnbreakable: true } },
+				{ type: 'vector', item: { type: 'rect', color: 'thirdFill', _isFillColorFromUnbreakable: true } },
+				{ type: 'vector', item: { type: 'rect', color: 'border' } }
+			];
+
+			ew.addFragment(fragment);
+
+			assert.deepEqual(page.items.map(item => item.item.color), ['pageBackground', 'firstFill', 'secondFill', 'thirdFill', 'border']);
+		});
 	});
 });


### PR DESCRIPTION
Fixes #2947

### Summary

Table cell background fills drawn inside an unbreakable block (`dontBreakRows: true` rows,
`unbreakable` stacks) were painted in reverse of their draw order. Where such fills overlap
the wrong one ended up on top — most visibly, an outer table with a `layout.fillColor` and
`dontBreakRows: true` painted its row fill over the cell fills of a nested table.

### Root cause

`TableProcessor` flags cell fills drawn while a transaction is open with
`_isFillColorFromUnbreakable`. On commit, `ElementWriter.addFragment` splices each flagged
fill into the page's background band at `ctx.backgroundLength[ctx.page]` so lines and text
paint above it. That index was the same for every fill in the block, so each splice
inserted its fill ahead of the previous one, reversing the order. 0.2.x pushed block items
in order and did not have this problem.

### Fix

Offset the insertion index by the number of fills already inserted from the same block.
The fills still land at the front of the page items, after any page background, but keep
their relative draw order — matching 0.2.x behaviour. Non-fill items are untouched.

### Before / after

Rendering the document from the issue with the current master build, the nested cell's
`#1C488A` fill is hidden behind the outer row's `#EAF1FC` fill and the white `X` is barely
legible. With this change the nested cell renders as a dark blue box with a white `X` on
the light blue row, pixel-identical to the 0.2.12 output for the same document.

### Tests

Added a unit test in `tests/unit/ElementWriter.spec.js` asserting that a fragment
containing several fills flagged as coming from an unbreakable block is committed in draw
order, after existing page background items and before the block's other vectors. It fails
on master and passes with the fix.

`npm run build` plus the full mocha suite: 484 passing, 56 pending, 0 failing. `eslint`
clean.
